### PR TITLE
accessrules: added package for storing access rules related to apparmor prompting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 )
 
 require (
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 // indirect
 	github.com/canonical/tcglog-parser v0.0.0-20210824131805-69fa1e9f0ad2 // indirect
 	github.com/kr/pretty v0.2.2-0.20200810074440-814ac30b4b18 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93 h1:F0bRDzPy/j2IX/iIWqCEA23S1nal+f7A+/vLyj6Ye+4=
 github.com/canonical/go-efilib v0.3.1-0.20220815143333-7e5151412e93/go.mod h1:9b2PNAuPcZsB76x75/uwH99D8CyH/A2y4rq1/+bvplg=
 github.com/canonical/go-sp800.108-kdf v0.0.0-20210314145419-a3359f2d21b9 h1:USzKjrfWo/ESzozv2i3OMM7XDgxrZRvaHFrKkIKRtwU=

--- a/prompting/accessrules/accessrules.go
+++ b/prompting/accessrules/accessrules.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 )
@@ -399,7 +400,7 @@ func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, pa
 	pathMap := ardb.permissionDBForUserSnapAppPermission(user, snap, app, permission).PathRules
 	matchingPatterns := make([]string, 0)
 	for pathPattern := range pathMap {
-		matched, err := filepath.Match(pathPattern, path)
+		matched, err := doublestar.Match(pathPattern, path)
 		if err != nil {
 			// only possible error is ErrBadPattern, which should not occur
 			return false, err

--- a/prompting/accessrules/accessrules.go
+++ b/prompting/accessrules/accessrules.go
@@ -1,0 +1,547 @@
+package accessrules
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/osutil"
+)
+
+var ErrPathPatternMissingFromTree = errors.New("path pattern was not found in the access rule tree")
+var ErrRuleIdMismatch = errors.New("the access rule ID in the tree does not match the expected rule ID")
+var ErrRuleIdNotFound = errors.New("access rule ID is not found")
+var ErrPathPatternConflict = errors.New("a rule with the same path pattern already exists in the tree")
+var ErrPermissionNotFound = errors.New("permission not found in the permissions list for the given rule")
+var ErrPermissionsEmpty = errors.New("all permissions have been removed from the permissions list of the given rule")
+var ErrNoPatterns = errors.New("no patterns given, cannot establish precedence")
+var ErrNoMatchingRule = errors.New("no access rules match the given path")
+var ErrInvalidAction = errors.New(`invalid rule action; must be "permit" or "deny"`)
+var ErrUserNotAllowed = errors.New("the given user is not allowed to access the access rule with the given ID")
+
+type LifespanType string
+
+const (
+	LifespanForever  LifespanType = "forever"
+	LifespanSession  LifespanType = "session"
+	LifespanSingle   LifespanType = "single"
+	LifespanTimespan LifespanType = "timespan"
+)
+
+type Lifespan struct {
+	Type     LifespanType `json:"type"`
+	Duration uint32       `json:"duration"`
+}
+
+type PermissionType string
+
+const (
+	PermissionExecute             PermissionType = "execute"
+	PermissionWrite               PermissionType = "write"
+	PermissionRead                PermissionType = "read"
+	PermissionAppend              PermissionType = "append"
+	PermissionCreate              PermissionType = "create"
+	PermissionDelete              PermissionType = "delete"
+	PermissionOpen                PermissionType = "open"
+	PermissionRename              PermissionType = "rename"
+	PermissionSetAttr             PermissionType = "set-attr"
+	PermissionGetAttr             PermissionType = "get-attr"
+	PermissionSetCred             PermissionType = "set-cred"
+	PermissionGetCred             PermissionType = "get-cred"
+	PermissionChangeMode          PermissionType = "change-mode"
+	PermissionChangeOwner         PermissionType = "change-owner"
+	PermissionChangeGroup         PermissionType = "change-group"
+	PermissionLock                PermissionType = "lock"
+	PermissionExecuteMap          PermissionType = "execute-map"
+	PermissionLink                PermissionType = "link"
+	PermissionChangeProfile       PermissionType = "change-profile"
+	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
+)
+
+type AccessRule struct {
+	Id          string           `json:"id"`
+	Timestamp   string           `json:"timestamp"`
+	User        uint32           `json:"user"`
+	Snap        string           `json:"snap"`
+	App         string           `json:"app"`
+	PathPattern string           `json:"path-pattern"`
+	Action      string           `json:"action"`
+	Lifespan    Lifespan         `json:"lifespan"`
+	Permissions []PermissionType `json:"permissions"`
+}
+
+func (rule *AccessRule) removePermissionFromPermissionsList(permission PermissionType) error {
+	if len(rule.Permissions) == 0 {
+		return ErrPermissionsEmpty
+	}
+	for i, perm := range rule.Permissions {
+		if perm == permission {
+			rule.Permissions = append(rule.Permissions[:i], rule.Permissions[i+1:]...)
+			if len(rule.Permissions) == 0 {
+				return ErrPermissionsEmpty
+			}
+			return nil
+		}
+	}
+	return ErrPermissionNotFound
+}
+
+func PermissionsListContains(list []PermissionType, permission PermissionType) bool {
+	for _, perm := range list {
+		if perm == permission {
+			return true
+		}
+	}
+	return false
+}
+
+type permissionDB struct {
+	// permissionDB contains a map from path pattern to access rule ID
+	PathRules map[string]string
+}
+
+type appDB struct {
+	// appDB contains a map from permission to permissionDB for a particular app
+	PerPermission map[PermissionType]*permissionDB
+}
+
+type snapDB struct {
+	// snapDB contains a map from app to appDB for a particular snap
+	PerApp map[string]*appDB
+}
+
+type userDB struct {
+	// userDB contains a map from snap to snapDB for a particular user
+	PerSnap map[string]*snapDB
+}
+
+type AccessRuleDB struct {
+	ById    map[string]*AccessRule
+	PerUser map[uint32]*userDB
+}
+
+func New() (*AccessRuleDB, error) {
+	ardb := &AccessRuleDB{
+		ById:    make(map[string]*AccessRule),
+		PerUser: make(map[uint32]*userDB),
+	}
+	return ardb, ardb.load()
+}
+
+func (ardb *AccessRuleDB) dbpath() string {
+	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "access-rules.json")
+}
+
+func (ardb *AccessRuleDB) permissionDBForUserSnapAppPermission(user uint32, snap string, app string, permission PermissionType) *permissionDB {
+	userSnaps := ardb.PerUser[user]
+	if userSnaps == nil {
+		userSnaps = &userDB{
+			PerSnap: make(map[string]*snapDB),
+		}
+		ardb.PerUser[user] = userSnaps
+	}
+	snapApps := userSnaps.PerSnap[snap]
+	if snapApps == nil {
+		snapApps = &snapDB{
+			PerApp: make(map[string]*appDB),
+		}
+		userSnaps.PerSnap[snap] = snapApps
+	}
+	appPerms := snapApps.PerApp[app]
+	if appPerms == nil {
+		appPerms = &appDB{
+			PerPermission: make(map[PermissionType]*permissionDB),
+		}
+		snapApps.PerApp[app] = appPerms
+	}
+	permPaths := appPerms.PerPermission[permission]
+	if permPaths == nil {
+		permPaths = &permissionDB{
+			PathRules: make(map[string]string),
+		}
+		appPerms.PerPermission[permission] = permPaths
+	}
+	return permPaths
+}
+
+func (ardb *AccessRuleDB) addRulePermissionToTree(rule *AccessRule, permission PermissionType) (error, string) {
+	// If there is a conflicting path pattern from another rule, returns an
+	// error along with the ID of the conflicting rule.
+	permPaths := ardb.permissionDBForUserSnapAppPermission(rule.User, rule.Snap, rule.App, permission)
+	pathPattern := rule.PathPattern
+	if id, exists := permPaths.PathRules[pathPattern]; exists {
+		return ErrPathPatternConflict, id
+	}
+	permPaths.PathRules[pathPattern] = rule.Id
+	return nil, ""
+}
+
+func (ardb *AccessRuleDB) removeRulePermissionFromTree(rule *AccessRule, permission PermissionType) error {
+	permPaths := ardb.permissionDBForUserSnapAppPermission(rule.User, rule.Snap, rule.App, permission)
+	pathPattern := rule.PathPattern
+	id, exists := permPaths.PathRules[pathPattern]
+	if !exists {
+		return ErrPathPatternMissingFromTree
+	}
+	if id != rule.Id {
+		return ErrRuleIdMismatch
+	}
+	delete(permPaths.PathRules, pathPattern)
+	return nil
+}
+
+func (ardb *AccessRuleDB) addRuleToTree(rule *AccessRule) (error, string, PermissionType) {
+	// If there is a conflicting path pattern from another rule, returns an
+	// error along with the ID of the conflicting rule and the permission for
+	// which the conflict occurred
+	addedPermissions := make([]PermissionType, 0, len(rule.Permissions))
+	for _, permission := range rule.Permissions {
+		if err, conflictingId := ardb.addRulePermissionToTree(rule, permission); err != nil {
+			for _, prevPerm := range addedPermissions {
+				ardb.removeRulePermissionFromTree(rule, prevPerm)
+			}
+			return err, conflictingId, permission
+		}
+		addedPermissions = append(addedPermissions, permission)
+	}
+	return nil, "", ""
+}
+
+func (ardb *AccessRuleDB) removeRuleFromTree(rule *AccessRule) error {
+	// fully removes the rule from the tree, even if an error occurs
+	var err error
+	for _, permission := range rule.Permissions {
+		if e := ardb.removeRulePermissionFromTree(rule, permission); e != nil {
+			// store the most recent non-nil error, but keep removing
+			err = e
+		}
+	}
+	return err
+}
+
+func getNewerRule(id1 string, ts1 string, id2 string, ts2 string) string {
+	// returns the id with the newest timestamp. If the timestamp for one id
+	// cannot be parsed, return the other id. If both cannot be parsed, return
+	// the id corresponding to the timestamp which is larger lexicographically.
+	// If there is a tie, return id1.
+	time1, err1 := time.Parse(time.RFC3339Nano, ts1)
+	time2, err2 := time.Parse(time.RFC3339Nano, ts2)
+	if err1 != nil {
+		if err2 != nil {
+			if strings.Compare(ts1, ts2) == -1 {
+				return id2
+			}
+			return id1
+		}
+		return id2
+	}
+	if time1.Compare(time2) == -1 {
+		return id2
+	}
+	return id1
+}
+
+// TODO: unexport (probably)
+func (ardb *AccessRuleDB) RefreshTreeEnforceConsistency() {
+	newById := make(map[string]*AccessRule)
+	ardb.PerUser = make(map[uint32]*userDB)
+	for id, rule := range ardb.ById {
+		err, conflictingId, conflictingPermission := ardb.addRuleToTree(rule)
+		for err != nil {
+			// err must be ErrPathPatternConflict
+			// prioritize newer rules by pruning permission from old rule until no conflicts remain
+			conflictingRule := ardb.ById[conflictingId] // must exist
+			if getNewerRule(id, rule.Timestamp, conflictingId, conflictingRule.Timestamp) == id {
+				ardb.removeRulePermissionFromTree(conflictingRule, conflictingPermission) // must return nil
+				if conflictingRule.removePermissionFromPermissionsList(conflictingPermission) == ErrPermissionsEmpty {
+					delete(newById, conflictingId)
+				}
+			} else {
+				rule.removePermissionFromPermissionsList(conflictingPermission) // ignore error
+			}
+			err, conflictingId, conflictingPermission = ardb.addRuleToTree(rule)
+		}
+		if len(rule.Permissions) > 0 {
+			newById[id] = rule
+		}
+	}
+	ardb.ById = newById
+}
+
+func (ardb *AccessRuleDB) load() error {
+	target := ardb.dbpath()
+	f, err := os.Open(target)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	accessRuleList := make([]*AccessRule, 0, 256) // pre-allocate a large array to reduce memcpys
+	json.NewDecoder(f).Decode(&accessRuleList)    // TODO: handle errors
+
+	ardb.ById = make(map[string]*AccessRule) // clear out any existing rules in ById
+	for _, rule := range accessRuleList {
+		ardb.ById[rule.Id] = rule
+	}
+
+	ardb.RefreshTreeEnforceConsistency()
+
+	return nil
+}
+
+func (ardb *AccessRuleDB) save() error {
+	ruleList := make([]*AccessRule, 0, len(ardb.ById))
+	for _, rule := range ardb.ById {
+		ruleList = append(ruleList, rule)
+	}
+	b, err := json.Marshal(ruleList)
+	if err != nil {
+		return err
+	}
+	target := ardb.dbpath()
+	if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+		return err
+	}
+	return osutil.AtomicWriteFile(target, b, 0600, 0)
+}
+
+func CurrentTimestamp() string {
+	return time.Now().Format(time.RFC3339Nano)
+}
+
+// TODO: unexport (probably, avoid confusion with CreateAccessRule)
+// Users of accessrules should probably autofill AccessRules from JSON and
+// never call this function directly.
+func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app string, pathPattern string, action string, lifespan Lifespan, permissions []PermissionType) *AccessRule {
+	timestamp := CurrentTimestamp()
+	newRule := AccessRule{
+		Id:          timestamp,
+		Timestamp:   timestamp,
+		User:        user,
+		Snap:        snap,
+		App:         app,
+		PathPattern: pathPattern,
+		Action:      action,
+		Lifespan:    lifespan,
+		Permissions: permissions,
+	}
+	return &newRule
+}
+
+var allowablePathPatternRegexp = regexp.MustCompile(`^(/|(/[^/*{}]+)*(/\*|(/\*\*)?(/\*\.[^/*{}]+)?)?)$`)
+
+func PathPatternAllowed(pattern string) bool {
+	return allowablePathPatternRegexp.MatchString(pattern)
+}
+
+func GetHighestPrecedencePattern(patterns []string) (string, error) {
+	if len(patterns) == 0 {
+		return "", ErrNoPatterns
+	}
+	// first find rules with extensions, if any exist -- these are most specific
+	// longer file extensions are more specific than longer paths, so
+	// /foo/bar/**/*.tar.gz is more specific than /foo/bar/baz/**/*.gz
+	extensions := make(map[string][]string)
+	for _, pattern := range patterns {
+		if strings.Index(pattern, "*") == -1 {
+			// exact match, has highest precedence
+			return pattern, nil
+		}
+		segments := strings.Split(pattern, "/")
+		finalSegment := segments[len(segments)-1]
+		extension, exists := strings.CutPrefix(finalSegment, "*.")
+		if !exists {
+			continue
+		}
+		extensions[extension] = append(extensions[extension], pattern)
+	}
+	longestExtension := ""
+	for extension, extPatterns := range extensions {
+		if len(extension) > len(longestExtension) {
+			longestExtension = extension
+			patterns = extPatterns
+		}
+	}
+	// either patterns all have same extension, or patterns have no extension (but possibly trailing /* or /**)
+	// prioritize longest patterns (excluding /** or /*)
+	longestCleanedLength := 0
+	longestCleanedPatterns := make([]string, 0)
+	for _, pattern := range patterns {
+		cleanedPattern := strings.ReplaceAll(pattern, "/**", "")
+		cleanedPattern = strings.ReplaceAll(cleanedPattern, "/*", "")
+		length := len(cleanedPattern)
+		if length < longestCleanedLength {
+			continue
+		}
+		if length > longestCleanedLength {
+			longestCleanedLength = length
+			longestCleanedPatterns = longestCleanedPatterns[:0] // clear but preserve allocated memory
+		}
+		longestCleanedPatterns = append(longestCleanedPatterns, pattern)
+	}
+	// longestCleanedPatterns is all the most-specific patterns that match
+	// Now, want to prioritize .../foo over .../foo/* over .../foo/**, so take shortest of these
+	shortestPattern := longestCleanedPatterns[0]
+	for _, pattern := range longestCleanedPatterns {
+		if len(pattern) < len(shortestPattern) {
+			shortestPattern = pattern
+		}
+	}
+	return shortestPattern, nil
+}
+
+func (ardb *AccessRuleDB) IsPathPermitted(user uint32, snap string, app string, path string, permission PermissionType) (bool, error) {
+	pathMap := ardb.permissionDBForUserSnapAppPermission(user, snap, app, permission).PathRules
+	matchingPatterns := make([]string, 0)
+	for pathPattern := range pathMap {
+		matched, err := filepath.Match(pathPattern, path)
+		if err != nil {
+			// only possible error is ErrBadPattern, which should not occur
+			return false, err
+		}
+		if matched {
+			matchingPatterns = append(matchingPatterns, pathPattern)
+		}
+	}
+	if len(matchingPatterns) == 0 {
+		return false, ErrNoMatchingRule
+	}
+	highestPrecedencePattern, err := GetHighestPrecedencePattern(matchingPatterns)
+	if err != nil {
+		return false, err
+	}
+	matchingId := pathMap[highestPrecedencePattern]
+	matchingRule, exists := ardb.ById[matchingId]
+	if !exists {
+		return false, ErrRuleIdNotFound
+	}
+	switch matchingRule.Action {
+	case "permit":
+		return true, nil
+	case "deny":
+		return false, nil
+	default:
+		return false, ErrInvalidAction
+	}
+}
+
+func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error) {
+	rule, exists := ardb.ById[id]
+	if !exists {
+		return nil, ErrRuleIdNotFound
+	}
+	if rule.User != user {
+		return nil, ErrUserNotAllowed
+	}
+	return rule, nil
+}
+
+func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, action string, lifespan Lifespan, permissions []PermissionType) (*AccessRule, error) {
+	newRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, action, lifespan, permissions)
+	if err, _, _ := ardb.addRuleToTree(newRule); err != nil {
+		// TODO: could return the conflicting rule ID and permission
+		return nil, err
+	}
+	ardb.ById[newRule.Id] = newRule
+	return newRule, nil
+}
+
+func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule, error) {
+	rule, err := ardb.RuleWithId(user, id)
+	if err != nil {
+		return nil, err
+	}
+	err = ardb.removeRuleFromTree(rule)
+	// if error occurs, rule was still fully removed from tree
+	delete(ardb.ById, id)
+	return rule, err
+}
+
+func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, action string, lifespan *Lifespan, permissions []PermissionType) (*AccessRule, error) {
+	rule, err := ardb.RuleWithId(user, id)
+	if err != nil {
+		return nil, err
+	}
+	if permissions == nil || len(permissions) == 0 {
+		// treat empty permissions list as leave permissions unchanged
+		// since go has little distinction between nil and empty list
+		permissions = rule.Permissions
+	}
+	if pathPattern != "" && pathPattern != rule.PathPattern {
+		// remove and re-add all permissions, since path must be changed
+		if err = ardb.removeRuleFromTree(rule); err != nil {
+			// if error occurs, rule is fully removed from tree
+			return nil, err
+		}
+		rule.Permissions = rule.Permissions[:0]
+		rule.PathPattern = pathPattern
+	}
+	preservedPermissions := make([]PermissionType, 0, len(rule.Permissions))
+	for _, permission := range rule.Permissions {
+		// remove permissions which are no longer included
+		if PermissionsListContains(permissions, permission) {
+			preservedPermissions = append(preservedPermissions, permission)
+		} else {
+			if err = ardb.removeRulePermissionFromTree(rule, permission); err != nil {
+				// if error occurs, rule and tree are not synchronized
+				// TODO: decide whether to remove rule entirely or revert to previous (broken) state
+				return nil, err
+			}
+		}
+	}
+	rule.Permissions = preservedPermissions
+	for _, permission := range permissions {
+		// add new permissions which were not previously included
+		if !PermissionsListContains(rule.Permissions, permission) {
+			if addingErr, _ := ardb.addRulePermissionToTree(rule, permission); err == nil {
+				// if error occurs, rule and tree are synchronized
+				err = addingErr
+			} else {
+				rule.Permissions = append(rule.Permissions, permission)
+			}
+		}
+	}
+	if action != "" {
+		rule.Action = action
+	}
+	if lifespan != nil {
+		rule.Lifespan = *lifespan
+	}
+	rule.Timestamp = CurrentTimestamp()
+	return rule, err
+}
+
+func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
+	rules := make([]*AccessRule, 0)
+	for _, rule := range ardb.ById {
+		if rule.User == user {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
+}
+
+func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
+	rules := make([]*AccessRule, 0)
+	for _, rule := range ardb.ById {
+		if rule.User == user && rule.Snap == snap {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
+}
+
+func (ardb *AccessRuleDB) RulesForSnapApp(user uint32, snap string, app string) []*AccessRule {
+	rules := make([]*AccessRule, 0)
+	for _, rule := range ardb.ById {
+		if rule.User == user && rule.Snap == snap && rule.App == app {
+			rules = append(rules, rule)
+		}
+	}
+	return rules
+}

--- a/prompting/accessrules/accessrules.go
+++ b/prompting/accessrules/accessrules.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
@@ -133,6 +134,7 @@ type userDB struct {
 type AccessRuleDB struct {
 	ById    map[string]*AccessRule
 	PerUser map[uint32]*userDB
+	mutex   sync.Mutex
 }
 
 func New() (*AccessRuleDB, error) {
@@ -473,6 +475,8 @@ func GetHighestPrecedencePattern(patterns []string) (string, error) {
 }
 
 func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, path string, permission PermissionType) (bool, error) {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	needToSave := false
 	pathMap := ardb.permissionDBForUserSnapAppPermission(user, snap, app, permission).PathRules
 	matchingPatterns := make([]string, 0)
@@ -537,7 +541,7 @@ func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, pa
 	}
 }
 
-func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error) {
+func (ardb *AccessRuleDB) ruleWithIdInternal(user uint32, id string) (*AccessRule, error) {
 	rule, exists := ardb.ById[id]
 	if !exists {
 		return nil, ErrRuleIdNotFound
@@ -548,7 +552,15 @@ func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error
 	return rule, nil
 }
 
+func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error) {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
+	return ardb.ruleWithIdInternal(user, id)
+}
+
 func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string, permissions []PermissionType) (*AccessRule, error) {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	newRule, err := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	if err != nil {
 		return nil, err
@@ -562,7 +574,9 @@ func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string,
 }
 
 func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule, error) {
-	rule, err := ardb.RuleWithId(user, id)
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
+	rule, err := ardb.ruleWithIdInternal(user, id)
 	if err != nil {
 		return nil, err
 	}
@@ -574,7 +588,9 @@ func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule,
 }
 
 func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string, permissions []PermissionType) (*AccessRule, error) {
-	origRule, err := ardb.RuleWithId(user, id)
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
+	origRule, err := ardb.ruleWithIdInternal(user, id)
 	if err != nil {
 		return nil, err
 	}
@@ -615,6 +631,8 @@ func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern s
 }
 
 func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)
 	for _, rule := range ardb.ById {
 		if rule.User == user {
@@ -625,6 +643,8 @@ func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
 }
 
 func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)
 	for _, rule := range ardb.ById {
 		if rule.User == user && rule.Snap == snap {
@@ -635,6 +655,8 @@ func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
 }
 
 func (ardb *AccessRuleDB) RulesForSnapApp(user uint32, snap string, app string) []*AccessRule {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)
 	for _, rule := range ardb.ById {
 		if rule.User == user && rule.Snap == snap && rule.App == app {

--- a/prompting/accessrules/accessrules.go
+++ b/prompting/accessrules/accessrules.go
@@ -102,6 +102,7 @@ func (rule *AccessRule) removePermissionFromPermissionsList(permission Permissio
 	return ErrPermissionNotFound
 }
 
+// Returns true if the given permissions list contains the given permission, else false.
 func PermissionsListContains(list []PermissionType, permission PermissionType) bool {
 	for _, perm := range list {
 		if perm == permission {
@@ -137,6 +138,8 @@ type AccessRuleDB struct {
 	mutex   sync.Mutex
 }
 
+// Creates a new access rule database, loads existing access rules from the
+// path given by dbpath(), and returns the populated database.
 func New() (*AccessRuleDB, error) {
 	ardb := &AccessRuleDB{
 		ById:    make(map[string]*AccessRule),
@@ -262,7 +265,18 @@ func getNewerRule(id1 string, ts1 string, id2 string, ts2 string) string {
 }
 
 // TODO: unexport (probably)
+// This function is only required if database is left inconsistent (should not
+// occur) or when loading, in case the stored rules on disk were corrupted.
+//
+// Discards the current access rule tree, then iterates through the rules in
+// ardb.ById and re-populates the tree.  If there are any conflicts between
+// rules (that is, rules share the same path pattern and one or more of the
+// same permissions), the conflicting permission is removed from the rule with
+// the earlier timestamp.  When the function returns, the database should be
+// fully internally consistent and without conflicting rules.
 func (ardb *AccessRuleDB) RefreshTreeEnforceConsistency() {
+	ardb.mutex.Lock()
+	defer ardb.mutex.Unlock()
 	needToSave := false
 	newById := make(map[string]*AccessRule)
 	ardb.PerUser = make(map[uint32]*userDB)
@@ -332,12 +346,15 @@ func (ardb *AccessRuleDB) save() error {
 	return osutil.AtomicWriteFile(target, b, 0600, 0)
 }
 
+// Returns the current time in the format expected by access rule timestamps.
 func CurrentTimestamp() string {
 	return time.Now().Format(time.RFC3339Nano)
 }
 
 var allowablePathPatternRegexp = regexp.MustCompile(`^(/|(/[^/*{}]+)*(/\*|(/\*\*)?(/\*\.[^/*{}]+)?)?)$`)
 
+// Checks that the given path pattern is valid.  Returns nil if so, otherwise
+// returns ErrInvalidPathPattern.
 func ValidatePathPattern(pattern string) error {
 	if !allowablePathPatternRegexp.MatchString(pattern) {
 		return ErrInvalidPathPattern
@@ -345,6 +362,8 @@ func ValidatePathPattern(pattern string) error {
 	return nil
 }
 
+// Checks that the given outcome is valid.  Returns nil if so, otherwise
+// returns ErrInvalidOutcome.
 func ValidateOutcome(outcome OutcomeType) error {
 	switch outcome {
 	case OutcomeAllow, OutcomeDeny:
@@ -390,6 +409,12 @@ func validatePatternOutcomeLifespanDuration(pathPattern string, outcome OutcomeT
 // TODO: unexport (probably, avoid confusion with CreateAccessRule)
 // Users of accessrules should probably autofill AccessRules from JSON and
 // never call this function directly.
+//
+// Constructs a new access rule with the given parameters as values, with the
+// exception of duration.  Uses the given duration, in addition to the current
+// time, to compute the expiration time for the rule, and stores that as part
+// of the access rule which is returned.  If any of the given parameters are
+// invalid, returns a corresponding error.
 func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	expiration, err := validatePatternOutcomeLifespanDuration(pathPattern, outcome, lifespan, duration)
 	if err != nil {
@@ -413,6 +438,16 @@ func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app st
 	return &newRule, nil
 }
 
+// Determines which of the path patterns in the given patterns list is the
+// most specific, and thus has the highest priority.  Assumes that all of the
+// given patterns satisfy ValidatePathPattern(), so this is not verified as
+// part of this function.
+//
+// Exact matches always have the highest priority.  Then, the pattern with the
+// most specific file extension has priority.  If no matching patterns have
+// file extensions (or if multiple share the most specific file extension),
+// then the longest pattern (excluding trailing * wildcards) is the most
+// specific.  Lastly, the priority order is: .../foo > .../foo/* > .../foo/**
 func GetHighestPrecedencePattern(patterns []string) (string, error) {
 	if len(patterns) == 0 {
 		return "", ErrNoPatterns
@@ -470,6 +505,9 @@ func GetHighestPrecedencePattern(patterns []string) (string, error) {
 	return shortestPattern, nil
 }
 
+// Checks whether the given path with the given permission is allowed or
+// denied by existing access rules for the given user, snap, and app.  If no
+// access rule applies, returns ErrNoMatchingRule.
 func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, path string, permission PermissionType) (bool, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -533,6 +571,7 @@ func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, pa
 	case "deny":
 		return false, nil
 	default:
+		// Outcome should have been validated, so this should not occur
 		return false, ErrInvalidOutcome
 	}
 }
@@ -548,12 +587,19 @@ func (ardb *AccessRuleDB) ruleWithIdInternal(user uint32, id string) (*AccessRul
 	return rule, nil
 }
 
+// Returns the rule with the given ID.
+// If the rule is not found, returns ErrRuleNotFound.
+// If the rule does not apply to the given user, returns ErrUserNotAllowed.
 func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	return ardb.ruleWithIdInternal(user, id)
 }
 
+// Creates an access rule with the given information and adds it to the rule
+// database.  If any of the given parameters are invalid, returns an error.
+// Otherwise, returns the newly-created access rule, and saves the database to
+// disk.
 func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -569,6 +615,9 @@ func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string,
 	return newRule, nil
 }
 
+// Removes the access rule with the given ID from the rules database.  If the
+// rule does not apply to the given user, returns ErrUserNotAllowed.  If
+// successful, saves the database to disk.
 func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -583,6 +632,16 @@ func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule,
 	return rule, err
 }
 
+// Modifies the access rule with the given ID.  The rule is modified by
+// constructing a new rule based on the given parameters, and then replacing
+// the old rule with the same ID with the new rule.  Any of the parameters
+// which are equal to the default/unset value for their types are replaced by
+// the corresponding values in the existing rule.  Even if the given new rule
+// contents exactly match the existing rule contents, the timestamp of the rule
+// is updated to the current time.  If there is any error while adding the
+// modified rule to the database, rolls back to the previous unmodified rule,
+// leaving the database unchanged.  If the database is changed, it is saved to
+// disk.
 func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -626,6 +685,7 @@ func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern s
 	return newRule, nil
 }
 
+// Returns all access rules which apply to the given user.
 func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -638,6 +698,7 @@ func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
 	return rules
 }
 
+// Returns all access rules which apply to the given user and the given snap.
 func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
@@ -650,6 +711,7 @@ func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
 	return rules
 }
 
+// Returns all access rules which apply to the given user, snap, and app.
 func (ardb *AccessRuleDB) RulesForSnapApp(user uint32, snap string, app string) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()

--- a/prompting/accessrules/accessrules.go
+++ b/prompting/accessrules/accessrules.go
@@ -356,32 +356,28 @@ func ValidateOutcome(outcome OutcomeType) error {
 
 // ValidateLifespanParseDuration checks that the given lifespan is valid and
 // that the given duration is valid for that lifespan.  If the lifespan is
-// LifespanTimespan, the duration must be parsable via time.ParseDuration and
-// yield a positive duration. Otherwise, it must be the empty string.
-// Returns an error if any of the above are invalid, otherwise computes the
+// LifespanTimespan, then duration must be a positive integer representing the
+// number of seconds for which the rule should be valid. Otherwise, it must be
+// 0. Returns an error if any of the above are invalid, otherwise computes the
 // expiration time of the rule based on the current time and the given duration
 // and returns it.
-func ValidateLifespanParseDuration(lifespan LifespanType, duration string) (string, error) {
+func ValidateLifespanParseDuration(lifespan LifespanType, duration int) (string, error) {
 	expirationString := ""
 	switch lifespan {
 	case LifespanForever, LifespanSession, LifespanSingle:
-		if duration != "" {
+		if duration != 0 {
 			return "", ErrInvalidDuration
 		}
 	case LifespanTimespan:
-		parsedDuration, err := time.ParseDuration(duration)
-		if err != nil {
-			return "", fmt.Errorf("%w: %w", ErrInvalidDuration, err)
-		}
-		if parsedDuration <= time.Duration(0) {
+		if duration <= 0 {
 			return "", ErrInvalidDuration
 		}
-		expirationString = time.Now().Add(parsedDuration).Format(time.RFC3339)
+		expirationString = time.Now().Add(time.Duration(duration) * time.Second).Format(time.RFC3339)
 	}
 	return expirationString, nil
 }
 
-func validatePatternOutcomeLifespanDuration(pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string) (string, error) {
+func validatePatternOutcomeLifespanDuration(pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int) (string, error) {
 	if err := ValidatePathPattern(pathPattern); err != nil {
 		return "", err
 	}
@@ -394,7 +390,7 @@ func validatePatternOutcomeLifespanDuration(pathPattern string, outcome OutcomeT
 // TODO: unexport (probably, avoid confusion with CreateAccessRule)
 // Users of accessrules should probably autofill AccessRules from JSON and
 // never call this function directly.
-func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string, permissions []PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	expiration, err := validatePatternOutcomeLifespanDuration(pathPattern, outcome, lifespan, duration)
 	if err != nil {
 		return nil, err
@@ -558,7 +554,7 @@ func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error
 	return ardb.ruleWithIdInternal(user, id)
 }
 
-func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string, permissions []PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	newRule, err := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
@@ -587,7 +583,7 @@ func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule,
 	return rule, err
 }
 
-func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration string, permissions []PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, outcome OutcomeType, lifespan LifespanType, duration int, permissions []PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	origRule, err := ardb.ruleWithIdInternal(user, id)

--- a/prompting/accessrules/accessrules_test.go
+++ b/prompting/accessrules/accessrules_test.go
@@ -362,7 +362,7 @@ func (s *accessruleSuite) TestIsPathAllowed(c *C) {
 	patterns["/home/test/Documents/**"] = "allow"
 	patterns["/home/test/Documents/foo/**"] = "deny"
 	patterns["/home/test/Documents/foo/bar/**"] = "allow"
-	patterns["/home/test/Documents/foo/bar/baz**"] = "deny"
+	patterns["/home/test/Documents/foo/bar/baz/**"] = "deny"
 	patterns["/home/test/**/*.png"] = "allow"
 	patterns["/home/test/**/*.jpg"] = "deny"
 

--- a/prompting/accessrules/accessrules_test.go
+++ b/prompting/accessrules/accessrules_test.go
@@ -184,7 +184,7 @@ func (s *accessruleSuite) TestCreateAccessRuleSimple(c *C) {
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
-	action := "permit"
+	outcome := "allow"
 	lifespan := accessrules.Lifespan{
 		Type:     accessrules.LifespanForever,
 		Duration: 0,
@@ -195,7 +195,7 @@ func (s *accessruleSuite) TestCreateAccessRuleSimple(c *C) {
 		accessrules.PermissionExecute,
 	}
 
-	accessRule, err := ardb.CreateAccessRule(user, snap, app, pathPattern, action, lifespan, permissions)
+	accessRule, err := ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, permissions)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(ardb.ById), Equals, 1)
@@ -235,7 +235,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
-	action := "permit"
+	outcome := "allow"
 	lifespan := accessrules.Lifespan{
 		Type:     accessrules.LifespanForever,
 		Duration: 0,
@@ -246,7 +246,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 		accessrules.PermissionExecute,
 	}
 
-	accessRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, action, lifespan, permissions)
+	accessRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, permissions)
 	ardb.ById[accessRule.Id] = accessRule
 	ardb.RefreshTreeEnforceConsistency()
 

--- a/prompting/accessrules/accessrules_test.go
+++ b/prompting/accessrules/accessrules_test.go
@@ -185,17 +185,15 @@ func (s *accessruleSuite) TestCreateAccessRuleSimple(c *C) {
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
 	outcome := "allow"
-	lifespan := accessrules.Lifespan{
-		Type:     accessrules.LifespanForever,
-		Duration: 0,
-	}
+	lifespan := accessrules.LifespanForever
+	duration := ""
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
 		accessrules.PermissionExecute,
 	}
 
-	accessRule, err := ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, permissions)
+	accessRule, err := ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	c.Assert(err, IsNil)
 
 	c.Assert(len(ardb.ById), Equals, 1)
@@ -236,17 +234,15 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
 	outcome := "allow"
-	lifespan := accessrules.Lifespan{
-		Type:     accessrules.LifespanForever,
-		Duration: 0,
-	}
+	lifespan := accessrules.LifespanForever
+	duration := ""
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
 		accessrules.PermissionExecute,
 	}
 
-	accessRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, permissions)
+	accessRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	ardb.ById[accessRule.Id] = accessRule
 	ardb.RefreshTreeEnforceConsistency()
 

--- a/prompting/accessrules/accessrules_test.go
+++ b/prompting/accessrules/accessrules_test.go
@@ -1,0 +1,276 @@
+package accessrules_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/prompting/accessrules"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type accessruleSuite struct {
+	tmpdir string
+}
+
+var _ = Suite(&accessruleSuite{})
+
+func (s *accessruleSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+}
+
+func (s *accessruleSuite) TestPermissionsListContains(c *C) {
+	permissionsList := []accessrules.PermissionType{
+		accessrules.PermissionExecute,
+		accessrules.PermissionWrite,
+		accessrules.PermissionRead,
+		accessrules.PermissionAppend,
+		accessrules.PermissionOpen,
+	}
+	for _, perm := range []accessrules.PermissionType{
+		accessrules.PermissionExecute,
+		accessrules.PermissionWrite,
+		accessrules.PermissionRead,
+		accessrules.PermissionAppend,
+		accessrules.PermissionOpen,
+	} {
+		c.Check(accessrules.PermissionsListContains(permissionsList, perm), Equals, true)
+	}
+	for _, perm := range []accessrules.PermissionType{
+		accessrules.PermissionCreate,
+		accessrules.PermissionDelete,
+		accessrules.PermissionRename,
+		accessrules.PermissionChangeOwner,
+		accessrules.PermissionChangeGroup,
+	} {
+		c.Check(accessrules.PermissionsListContains(permissionsList, perm), Equals, false)
+	}
+}
+
+func (s *accessruleSuite) TestPathPatternAllowed(c *C) {
+	for _, pattern := range []string{
+		"/",
+		"/*",
+		"/**",
+		"/**/*.txt",
+		"/foo",
+		"/foo",
+		"/foo/file.txt",
+		"/foo/bar",
+		"/foo/bar/*",
+		"/foo/bar/*.tar.gz",
+		"/foo/bar/**",
+		"/foo/bar/**/*.zip",
+	} {
+		c.Check(accessrules.PathPatternAllowed(pattern), Equals, true, Commentf("valid path pattern `%s` was incorrectly not allowed", pattern))
+	}
+
+	for _, pattern := range []string{
+		"file.txt",
+		"/**/*",
+		"/foo/*/bar",
+		"/foo/**/bar",
+		"/foo/bar/",
+		"/foo/bar*",
+		"/foo/bar*.txt",
+		"/foo/bar**",
+		"/foo/bar/*txt",
+		"/foo/bar/**.txt",
+		"/foo/bar/*/file.txt",
+		"/foo/bar/**/file.txt",
+		"/foo/bar/**/*",
+		"/foo/bar/**/*txt",
+	} {
+		c.Check(accessrules.PathPatternAllowed(pattern), Equals, false, Commentf("invalid path pattern `%s` was incorrectly allowed", pattern))
+	}
+}
+
+func (s *accessruleSuite) TestGetHighestPrecedencePattern(c *C) {
+	for i, testCase := range []struct {
+		Patterns          []string
+		HighestPrecedence string
+	}{
+		{
+			[]string{
+				"/foo",
+			},
+			"/foo",
+		},
+		{
+			[]string{
+				"/foo",
+				"/foo/*",
+			},
+			"/foo",
+		},
+		{
+			[]string{
+				"/foo",
+				"/foo/**",
+			},
+			"/foo",
+		},
+		{
+			[]string{
+				"/foo/*",
+				"/foo/**",
+			},
+			"/foo/*",
+		},
+		{
+			[]string{
+				"/foo",
+				"/foo/*",
+				"/foo/**",
+			},
+			"/foo",
+		},
+		{
+			[]string{
+				"/foo/*",
+				"/foo/bar",
+			},
+			"/foo/bar",
+		},
+		{
+			[]string{
+				"/foo/**",
+				"/foo/bar",
+			},
+			"/foo/bar",
+		},
+		{
+			[]string{
+				"/foo/**",
+				"/foo/bar/file.txt",
+			},
+			"/foo/bar/file.txt",
+		},
+		{
+			[]string{
+				"/foo/**/*.txt",
+				"/foo/bar/**",
+			},
+			"/foo/**/*.txt",
+		},
+		{
+			[]string{
+				"/foo/**/*.gz",
+				"/foo/**/*.tar.gz",
+			},
+			"/foo/**/*.tar.gz",
+		},
+		{
+			[]string{
+				"/foo/bar/**/*.gz",
+				"/foo/**/*.tar.gz",
+			},
+			"/foo/**/*.tar.gz",
+		},
+	} {
+		highestPrecedence, err := accessrules.GetHighestPrecedencePattern(testCase.Patterns)
+		c.Check(err, IsNil, Commentf("Error occurred during test case %d:\n%+v", i, testCase))
+		c.Check(highestPrecedence, Equals, testCase.HighestPrecedence, Commentf("Highest precedence pattern incorrect for test case %d:\n%+v", i, testCase))
+	}
+}
+
+func (s *accessruleSuite) TestCreateAccessRuleSimple(c *C) {
+	ardb, _ := accessrules.New()
+
+	var user uint32 = 1000
+	snap := "lxd"
+	app := "lxc"
+	pathPattern := "/home/test/Documents/**"
+	action := "permit"
+	lifespan := accessrules.Lifespan{
+		Type:     accessrules.LifespanForever,
+		Duration: 0,
+	}
+	permissions := []accessrules.PermissionType{
+		accessrules.PermissionRead,
+		accessrules.PermissionWrite,
+		accessrules.PermissionExecute,
+	}
+
+	accessRule, err := ardb.CreateAccessRule(user, snap, app, pathPattern, action, lifespan, permissions)
+	c.Assert(err, IsNil)
+
+	c.Assert(len(ardb.ById), Equals, 1)
+	storedRule, exists := ardb.ById[accessRule.Id]
+	c.Assert(exists, Equals, true)
+	c.Assert(storedRule, DeepEquals, accessRule)
+
+	c.Assert(len(ardb.PerUser), Equals, 1)
+
+	userEntry, exists := ardb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(userEntry.PerSnap), Equals, 1)
+
+	snapEntry, exists := userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(snapEntry.PerApp), Equals, 1)
+
+	appEntry, exists := snapEntry.PerApp[app]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(appEntry.PerPermission), Equals, 3)
+
+	for _, permission := range permissions {
+		permissionEntry, exists := appEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		c.Assert(len(permissionEntry.PathRules), Equals, 1)
+
+		pathId, exists := permissionEntry.PathRules[pathPattern]
+		c.Assert(exists, Equals, true)
+		c.Assert(pathId, Equals, accessRule.Id)
+	}
+}
+
+func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
+	ardb, _ := accessrules.New()
+
+	var user uint32 = 1000
+	snap := "lxd"
+	app := "lxc"
+	pathPattern := "/home/test/Documents/**"
+	action := "permit"
+	lifespan := accessrules.Lifespan{
+		Type:     accessrules.LifespanForever,
+		Duration: 0,
+	}
+	permissions := []accessrules.PermissionType{
+		accessrules.PermissionRead,
+		accessrules.PermissionWrite,
+		accessrules.PermissionExecute,
+	}
+
+	accessRule := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, action, lifespan, permissions)
+	ardb.ById[accessRule.Id] = accessRule
+	ardb.RefreshTreeEnforceConsistency()
+
+	c.Assert(len(ardb.PerUser), Equals, 1)
+
+	userEntry, exists := ardb.PerUser[user]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(userEntry.PerSnap), Equals, 1)
+
+	snapEntry, exists := userEntry.PerSnap[snap]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(snapEntry.PerApp), Equals, 1)
+
+	appEntry, exists := snapEntry.PerApp[app]
+	c.Assert(exists, Equals, true)
+	c.Assert(len(appEntry.PerPermission), Equals, 3)
+
+	for _, permission := range permissions {
+		permissionEntry, exists := appEntry.PerPermission[permission]
+		c.Assert(exists, Equals, true)
+		c.Assert(len(permissionEntry.PathRules), Equals, 1)
+
+		pathId, exists := permissionEntry.PathRules[pathPattern]
+		c.Assert(exists, Equals, true)
+		c.Assert(pathId, Equals, accessRule.Id)
+	}
+}

--- a/prompting/accessrules/accessrules_test.go
+++ b/prompting/accessrules/accessrules_test.go
@@ -99,10 +99,9 @@ func (s *accessruleSuite) TestValidateOutcome(c *C) {
 }
 
 func (s *accessruleSuite) TestValidateLifespanParseDuration(c *C) {
-	unsetDuration := ""
-	sampleDuration := "10m"
-	sampleDurationAsTime, err := time.ParseDuration(sampleDuration)
-	c.Assert(err, IsNil)
+	unsetDuration := 0
+	sampleDuration := 600
+	sampleDurationAsTime := time.Duration(sampleDuration) * time.Second
 
 	for _, lifespan := range []accessrules.LifespanType{
 		accessrules.LifespanForever,
@@ -119,7 +118,7 @@ func (s *accessruleSuite) TestValidateLifespanParseDuration(c *C) {
 
 	expiration, err := accessrules.ValidateLifespanParseDuration(accessrules.LifespanTimespan, unsetDuration)
 	c.Check(expiration, Equals, "")
-	c.Check(err, ErrorMatches, fmt.Sprintf("^%s: .*", accessrules.ErrInvalidDuration))
+	c.Check(err, Equals, accessrules.ErrInvalidDuration)
 
 	expiration, err = accessrules.ValidateLifespanParseDuration(accessrules.LifespanTimespan, sampleDuration)
 	c.Check(err, Equals, nil)
@@ -137,7 +136,7 @@ func (s *accessruleSuite) TestPopulateNewAccessRule(c *C) {
 	app := "lxc"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanSession
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -270,7 +269,7 @@ func (s *accessruleSuite) TestCreateDeleteAccessRuleSimple(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -344,7 +343,7 @@ func (s *accessruleSuite) TestCreateAccessRuleUnhappy(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -376,7 +375,7 @@ func (s *accessruleSuite) TestModifyAccessRule(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -404,7 +403,7 @@ func (s *accessruleSuite) TestModifyAccessRule(c *C) {
 	c.Assert(unchangedRule1, DeepEquals, storedRule)
 	c.Assert(ardb.ById, HasLen, 2)
 
-	unchangedRule2, err := ardb.ModifyAccessRule(user, storedRule.Id, "", accessrules.OutcomeUnset, accessrules.LifespanUnset, "", nil)
+	unchangedRule2, err := ardb.ModifyAccessRule(user, storedRule.Id, "", accessrules.OutcomeUnset, accessrules.LifespanUnset, 0, nil)
 	c.Assert(err, IsNil)
 	// Timestamp should be different, the rest should be the same
 	unchangedRule2.Timestamp = storedRule.Timestamp
@@ -414,7 +413,7 @@ func (s *accessruleSuite) TestModifyAccessRule(c *C) {
 	newPathPattern := otherPathPattern
 	newOutcome := accessrules.OutcomeDeny
 	newLifespan := accessrules.LifespanTimespan
-	newDuration := "1s"
+	newDuration := 1
 	newPermissions := []accessrules.PermissionType{accessrules.PermissionAppend}
 	modifiedRule, err := ardb.ModifyAccessRule(user, storedRule.Id, newPathPattern, newOutcome, newLifespan, newDuration, newPermissions)
 	c.Assert(err, IsNil)
@@ -450,7 +449,7 @@ func (s *accessruleSuite) TestRuleWithId(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -483,7 +482,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -529,7 +528,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencyComplex(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -630,7 +629,7 @@ func (s *accessruleSuite) TestNewSaveLoad(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -656,7 +655,7 @@ func (s *accessruleSuite) TestIsPathAllowed(c *C) {
 	snap := "lxd"
 	app := "lxc"
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,
@@ -734,21 +733,21 @@ func (s *accessruleSuite) TestRuleExpiration(c *C) {
 	pathPattern := "/home/test/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanSingle
-	duration := ""
+	duration := 0
 	_, err := ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	c.Assert(err, IsNil)
 
 	pathPattern = "/home/test/Pictures/**"
 	outcome = accessrules.OutcomeDeny
 	lifespan = accessrules.LifespanTimespan
-	duration = "2s"
+	duration = 2
 	_, err = ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	c.Assert(err, IsNil)
 
 	pathPattern = "/home/test/Pictures/**/*.png"
 	outcome = accessrules.OutcomeAllow
 	lifespan = accessrules.LifespanTimespan
-	duration = "1s"
+	duration = 1
 	_, err = ardb.CreateAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	c.Assert(err, IsNil)
 
@@ -798,7 +797,7 @@ func (s *accessruleSuite) TestRulesLookup(c *C) {
 	pathPattern := "/home/test/Documents/**"
 	outcome := accessrules.OutcomeAllow
 	lifespan := accessrules.LifespanForever
-	duration := ""
+	duration := 0
 	permissions := []accessrules.PermissionType{
 		accessrules.PermissionRead,
 		accessrules.PermissionWrite,


### PR DESCRIPTION
The exported functions in the accessrules package map closely to the future snapd REST API endpoints related to access rules. They will eventually be called the handle these API requests.

More work remains to be done to flesh out the unit tests (only very rudimentary ones are in place at the moment).