### PR TITLE
o/ifacestate: add `promptrequests` package to store apparmor prompt requests

### DIFF
--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/snapcore/snapd/dirs"
 	"github.com/snapcore/snapd/osutil"
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
@@ -356,7 +355,7 @@ func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, pa
 				continue
 			}
 		}
-		matched, err := doublestar.Match(pathPattern, path)
+		matched, err := common.PathPatternMatches(pathPattern, path)
 		if err != nil {
 			// Only possible error is ErrBadPattern, which should not occur
 			return false, err

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	doublestar "github.com/bmatcuk/doublestar/v4"
 	"github.com/snapcore/snapd/prompting/apparmor"
 )
 
@@ -68,7 +69,7 @@ const (
 // If the given permission is not found in the list, returns an error, along
 // with the original list.
 func RemovePermissionFromList(list []PermissionType, permission PermissionType) ([]PermissionType, error) {
-	newList := make([]PermissionType, 0, len(list)-1)
+	newList := make([]PermissionType, 0, len(list))
 	found := false
 	for _, perm := range list {
 		if perm == permission {
@@ -325,4 +326,8 @@ func GetHighestPrecedencePattern(patterns []string) (string, error) {
 		}
 	}
 	return shortestPattern, nil
+}
+
+func PathPatternMatches(pathPattern string, path string) (bool, error) {
+	return doublestar.Match(pathPattern, path)
 }

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -69,7 +69,10 @@ const (
 // If the given permission is not found in the list, returns an error, along
 // with the original list.
 func RemovePermissionFromList(list []PermissionType, permission PermissionType) ([]PermissionType, error) {
-	newList := make([]PermissionType, 0, len(list))
+	if len(list) == 0 {
+		return list, ErrPermissionNotInList
+	}
+	newList := make([]PermissionType, 0, len(list)-1)
 	found := false
 	for _, perm := range list {
 		if perm == permission {

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -489,3 +489,97 @@ func (s *commonSuite) TestGetHighestPrecedencePattern(c *C) {
 	c.Check(err, Equals, common.ErrNoPatterns)
 	c.Check(empty, Equals, "")
 }
+
+func (*commonSuite) TestPathPatternMatches(c *C) {
+	cases := []struct {
+		pattern string
+		path    string
+		matches bool
+	}{
+		{
+			"/home/test/Documents/foo.txt",
+			"/home/test/Documents/foo.txt",
+			true,
+		},
+		{
+			"/home/test/Documents/foo",
+			"/home/test/Documents/foo.txt",
+			false,
+		},
+		{
+			"/home/test/Documents/*",
+			"/home/test/Documents/foo.txt",
+			true,
+		},
+		{
+			"/home/test/Documents/**",
+			"/home/test/Documents/foo.txt",
+			true,
+		},
+		{
+			"/home/test/Documents/**/*.txt",
+			"/home/test/Documents/foo.txt",
+			true,
+		},
+		{
+			"/home/test/Documents/**/*.txt",
+			"/home/test/Documents/foo/bar.tar.gz",
+			false,
+		},
+		{
+			"/home/test/Documents/**",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/Documents/**/*.gz",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/Documents/**/*.tar.gz",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/Documents/*.tar.gz",
+			"/home/test/Documents/foo/bar.tar.gz",
+			false,
+		},
+		{
+			"/home/test/Documents/*",
+			"/home/test/Documents/foo/bar.tar.gz",
+			false,
+		},
+		{
+			"/home/test/**",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/*",
+			"/home/test/Documents/foo/bar.tar.gz",
+			false,
+		},
+		{
+			"/home/test/**/*.tar.gz",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/**/*.gz",
+			"/home/test/Documents/foo/bar.tar.gz",
+			true,
+		},
+		{
+			"/home/test/**/*.txt",
+			"/home/test/Documents/foo/bar.tar.gz",
+			false,
+		},
+	}
+	for _, testCase := range cases {
+		result, err := common.PathPatternMatches(testCase.pattern, testCase.path)
+		c.Check(err, IsNil, Commentf("test case: %+v", testCase))
+		c.Check(result, Equals, testCase.matches, Commentf("test case: %+v", testCase))
+	}
+}

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
@@ -1,0 +1,160 @@
+package promptrequests
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+)
+
+var ErrConflictingRequestId = errors.New("a prompt request with the same ID already exists")
+var ErrRequestIdNotFound = errors.New("no request with the given ID found for the given user")
+var ErrUserNotFound = errors.New("no prompt requests found for the given user")
+
+type PromptRequest struct {
+	Id          string                  `json:"id"`
+	Timestamp   string                  `json:"timestamp"`
+	Snap        string                  `json:"snap"`
+	App         string                  `json:"app"`
+	Path        string                  `json:"path"`
+	Permissions []common.PermissionType `json:"permissions"`
+	replyChan   chan bool
+}
+
+type userRequestDB struct {
+	ById map[string]*PromptRequest
+}
+
+type RequestDB struct {
+	PerUser map[uint32]*userRequestDB
+	mutex   sync.Mutex
+}
+
+func New() *RequestDB {
+	return &RequestDB{
+		PerUser: make(map[uint32]*userRequestDB),
+	}
+}
+
+// Creates, adds, and returns a new prompt request from the given parameters.
+func (rdb *RequestDB) Add(user uint32, snap string, app string, path string, permissions []common.PermissionType, replyChan chan bool) *PromptRequest {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	userEntry, exists := rdb.PerUser[user]
+	if !exists {
+		rdb.PerUser[user] = &userRequestDB{
+			ById: make(map[string]*PromptRequest),
+		}
+		userEntry = rdb.PerUser[user]
+	}
+	id, timestamp := common.NewIdAndTimestamp()
+	req := &PromptRequest{
+		Id:          id,
+		Timestamp:   timestamp,
+		Snap:        snap,
+		App:         app,
+		Path:        path,
+		Permissions: permissions, // TODO: copy permissions list?
+		replyChan:   replyChan,
+	}
+	userEntry.ById[id] = req
+	return req
+}
+
+func (rdb *RequestDB) Requests(user uint32) []*PromptRequest {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	userEntry, exists := rdb.PerUser[user]
+	if !exists {
+		return nil
+	}
+	requests := make([]*PromptRequest, 0, len(userEntry.ById))
+	for _, req := range userEntry.ById {
+		requests = append(requests, req)
+	}
+	return requests
+}
+
+func (rdb *RequestDB) RequestWithId(user uint32, id string) (*PromptRequest, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	userEntry, exists := rdb.PerUser[user]
+	if !exists {
+		return nil, ErrUserNotFound
+	}
+	req, exists := userEntry.ById[id]
+	if !exists {
+		return nil, ErrRequestIdNotFound
+	}
+	return req, nil
+}
+
+func (rdb *RequestDB) Reply(user uint32, id string, outcome common.OutcomeType) error {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	userEntry, exists := rdb.PerUser[user]
+	if !exists || len(userEntry.ById) == 0 {
+		return ErrUserNotFound
+	}
+	req, exists := userEntry.ById[id]
+	if !exists {
+		return ErrRequestIdNotFound
+	}
+	switch outcome {
+	case common.OutcomeAllow:
+		req.replyChan <- true
+	case common.OutcomeDeny:
+		req.replyChan <- false
+	default:
+		// should never occur
+	}
+	delete(userEntry.ById, id)
+	return nil
+}
+
+// If any existing requests are satisfied by the given rule, send the decision
+// along their respective channels, and return their IDs.
+func (rdb *RequestDB) HandleNewRule(user uint32, snap string, app string, pathPattern string, outcome common.OutcomeType, permissions []common.PermissionType) ([]string, error) {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	var satisfiedReqIds []string
+	userEntry, exists := rdb.PerUser[user]
+	if !exists {
+		return satisfiedReqIds, nil
+	}
+	for id, req := range userEntry.ById {
+		if !(snap == req.Snap && app == req.App) {
+			continue
+		}
+		matched, err := common.PathPatternMatches(pathPattern, req.Path)
+		if err != nil {
+			// Only possible error is ErrBadPattern
+			return nil, err
+		}
+		if !matched {
+			continue
+		}
+		remainingPermissions := req.Permissions
+		for _, perm := range permissions {
+			remainingPermissions, _ = common.RemovePermissionFromList(remainingPermissions, perm)
+		}
+		if len(remainingPermissions) > 0 {
+			// If we don't satisfy all permissions with the new rule,
+			// leave it up to the UI to prompt for all at once.
+			continue
+		}
+		// all permissions of request satisfied
+		switch outcome {
+		case common.OutcomeAllow:
+			req.replyChan <- true
+		case common.OutcomeDeny:
+			req.replyChan <- false
+		default:
+			// should never occur
+			continue // XXX TODO: add unit test to make sure continue continues to for loop
+		}
+		delete(userEntry.ById, id)
+		satisfiedReqIds = append(satisfiedReqIds, id)
+	}
+	return satisfiedReqIds, nil
+}

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
@@ -1,0 +1,294 @@
+package promptrequests_test
+
+import (
+	"testing"
+	"time"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/snapcore/snapd/dirs"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/promptrequests"
+	"github.com/snapcore/snapd/strutil"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type promptrequestsSuite struct {
+	tmpdir string
+}
+
+var _ = Suite(&promptrequestsSuite{})
+
+func (s *promptrequestsSuite) SetUpTest(c *C) {
+	s.tmpdir = c.MkDir()
+	dirs.SetRootDir(s.tmpdir)
+}
+
+func (s *promptrequestsSuite) TestNew(c *C) {
+	prdb := promptrequests.New()
+	c.Assert(prdb.PerUser, HasLen, 0)
+}
+
+func (s *promptrequestsSuite) TestAddRequests(c *C) {
+	rdb := promptrequests.New()
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan := make(chan bool)
+
+	stored := rdb.Requests(user)
+	c.Assert(stored, HasLen, 0)
+
+	before := time.Now()
+	req := rdb.Add(user, snap, app, path, permissions, replyChan)
+	after := time.Now()
+
+	timestamp, err := common.TimestampToTime(req.Timestamp)
+	c.Assert(err, IsNil)
+	c.Assert(timestamp.After(before), Equals, true)
+	c.Assert(timestamp.Before(after), Equals, true)
+
+	c.Assert(req.Snap, Equals, snap)
+	c.Assert(req.App, Equals, app)
+	c.Assert(req.Path, Equals, path)
+	c.Assert(req.Permissions, DeepEquals, permissions)
+
+	stored = rdb.Requests(user)
+	c.Assert(stored, HasLen, 1)
+	c.Assert(stored[0], DeepEquals, req)
+
+	storedReq, err := rdb.RequestWithId(user, req.Id)
+	c.Assert(err, IsNil)
+	c.Assert(storedReq, DeepEquals, req)
+}
+
+func (s *promptrequestsSuite) TestRequestWithIdErrors(c *C) {
+	rdb := promptrequests.New()
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan := make(chan bool)
+
+	req := rdb.Add(user, snap, app, path, permissions, replyChan)
+
+	result, err := rdb.RequestWithId(user, req.Id)
+	c.Assert(err, IsNil)
+	c.Assert(result, DeepEquals, req)
+
+	result, err = rdb.RequestWithId(user, "foo")
+	c.Assert(err, Equals, promptrequests.ErrRequestIdNotFound)
+	c.Assert(result, IsNil)
+
+	result, err = rdb.RequestWithId(user+1, "foo")
+	c.Assert(err, Equals, promptrequests.ErrUserNotFound)
+	c.Assert(result, IsNil)
+}
+
+func (s *promptrequestsSuite) TestReply(c *C) {
+	rdb := promptrequests.New()
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan := make(chan bool)
+
+	req := rdb.Add(user, snap, app, path, permissions, replyChan)
+
+	outcome := common.OutcomeAllow
+	go rdb.Reply(user, req.Id, outcome)
+	result := <-replyChan
+	c.Assert(result, Equals, true)
+
+	req = rdb.Add(user, snap, app, path, permissions, replyChan)
+
+	outcome = common.OutcomeDeny
+	go rdb.Reply(user, req.Id, outcome)
+	result = <-replyChan
+	c.Assert(result, Equals, false)
+}
+
+func (s *promptrequestsSuite) TestReplyErrors(c *C) {
+	rdb := promptrequests.New()
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan := make(chan bool)
+
+	_ = rdb.Add(user, snap, app, path, permissions, replyChan)
+
+	outcome := common.OutcomeAllow
+
+	err := rdb.Reply(user, "foo", outcome)
+	c.Assert(err, Equals, promptrequests.ErrRequestIdNotFound)
+
+	err = rdb.Reply(user+1, "foo", outcome)
+	c.Assert(err, Equals, promptrequests.ErrUserNotFound)
+}
+
+func (s *promptrequestsSuite) TestHandleNewRuleAllowPermissions(c *C) {
+	rdb := promptrequests.New()
+
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan1 := make(chan bool)
+	_ = rdb.Add(user, snap, app, path, permissions, replyChan1)
+
+	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead}
+	replyChan2 := make(chan bool, 1)
+	req2 := rdb.Add(user, snap, app, path, permissions, replyChan2)
+
+	permissions = []common.PermissionType{common.PermissionRead}
+	replyChan3 := make(chan bool, 1)
+	req3 := rdb.Add(user, snap, app, path, permissions, replyChan3)
+
+	permissions = []common.PermissionType{common.PermissionOpen}
+	replyChan4 := make(chan bool)
+	_ = rdb.Add(user, snap, app, path, permissions, replyChan4)
+
+	stored := rdb.Requests(user)
+	c.Assert(stored, HasLen, 4)
+
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead, common.PermissionAppend}
+
+	satisfied, err := rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 2)
+	c.Assert(strutil.ListContains(satisfied, req2.Id), Equals, true)
+	c.Assert(strutil.ListContains(satisfied, req3.Id), Equals, true)
+
+	result2 := <-replyChan2
+	result3 := <-replyChan3
+	c.Assert(result2, Equals, true)
+	c.Assert(result3, Equals, true)
+
+	stored = rdb.Requests(user)
+	c.Assert(stored, HasLen, 2)
+}
+
+func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
+	rdb := promptrequests.New()
+
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+
+	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
+	replyChan1 := make(chan bool)
+	_ = rdb.Add(user, snap, app, path, permissions, replyChan1)
+
+	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead}
+	replyChan2 := make(chan bool, 1)
+	req2 := rdb.Add(user, snap, app, path, permissions, replyChan2)
+
+	permissions = []common.PermissionType{common.PermissionRead}
+	replyChan3 := make(chan bool, 1)
+	req3 := rdb.Add(user, snap, app, path, permissions, replyChan3)
+
+	permissions = []common.PermissionType{common.PermissionOpen}
+	replyChan4 := make(chan bool)
+	_ = rdb.Add(user, snap, app, path, permissions, replyChan4)
+
+	stored := rdb.Requests(user)
+	c.Assert(stored, HasLen, 4)
+
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeDeny
+	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead, common.PermissionAppend}
+
+	satisfied, err := rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 2)
+	c.Assert(strutil.ListContains(satisfied, req2.Id), Equals, true)
+	c.Assert(strutil.ListContains(satisfied, req3.Id), Equals, true)
+
+	result2 := <-replyChan2
+	result3 := <-replyChan3
+	c.Assert(result2, Equals, false)
+	c.Assert(result3, Equals, false)
+
+	stored = rdb.Requests(user)
+	c.Assert(stored, HasLen, 2)
+
+	// check that denying the final missing permission does not deny the whole rule.
+	// TODO: change this behaviour?
+	permissions = []common.PermissionType{common.PermissionExecute}
+	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+}
+
+func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
+	rdb := promptrequests.New()
+
+	var user uint32 = 1000
+	snap := "nextcloud"
+	app := "occ"
+	path := "/home/test/Documents/foo.txt"
+	permissions := []common.PermissionType{common.PermissionRead}
+	replyChan := make(chan bool, 1)
+	req := rdb.Add(user, snap, app, path, permissions, replyChan)
+
+	pathPattern := "/home/test/Documents/**"
+	outcome := common.OutcomeAllow
+
+	otherUser := user + 1
+	otherSnap := "ldx"
+	otherApp := "lxc"
+	otherPattern := "/home/test/Pictures/**.png"
+	badPattern := "\\home\\test\\"
+	badOutcome := common.OutcomeType("foo")
+
+	stored := rdb.Requests(user)
+	c.Assert(stored, HasLen, 1)
+	c.Assert(stored[0], DeepEquals, req)
+
+	satisfied, err := rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherPattern, badOutcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, otherSnap, otherApp, otherPattern, badOutcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, snap, otherApp, otherPattern, badOutcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, snap, app, otherPattern, badOutcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, snap, app, badPattern, badOutcome, permissions)
+	c.Assert(err, ErrorMatches, "syntax error in pattern")
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, badOutcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	c.Assert(err, IsNil)
+	c.Assert(satisfied, HasLen, 1)
+
+	result := <-replyChan
+	c.Assert(result, Equals, true)
+
+	stored = rdb.Requests(user)
+	c.Assert(stored, HasLen, 0)
+}


### PR DESCRIPTION
This PR adds a new package `overlord/ifacestate/apparmorprompting/promptrequests` to store apparmor prompt requests.