### PR TITLE
prompting: allow access via snapd-snap.socket

### DIFF
--- a/daemon/api_access_control.go
+++ b/daemon/api_access_control.go
@@ -44,8 +44,8 @@ var (
 		Path:        "/v2/access-control/rules/{id}",
 		GET:         getRule,
 		POST:        postRule,
-		ReadAccess:  openAccess{},
-		WriteAccess: openAccess{},
+		ReadAccess:  promptingOpenAccess{},
+		WriteAccess: promptingOpenAccess{},
 		// TODO: make these authenticatedAccess{Polkit: polkitActionPrompting}
 		// Need to add polkitActionPrompting to daemon/api.go and register
 		// prompt UI clients with it.

--- a/daemon/api_access_control.go
+++ b/daemon/api_access_control.go
@@ -33,8 +33,8 @@ var (
 		Path:        "/v2/access-control/rules",
 		GET:         getRules,
 		POST:        postRules,
-		ReadAccess:  openAccess{},
-		WriteAccess: openAccess{},
+		ReadAccess:  promptingOpenAccess{},
+		WriteAccess: promptingOpenAccess{},
 		// TODO: make this authenticatedAccess{Polkit: polkitActionPrompting}
 		// Need to add polkitActionPrompting to daemon/api.go and register
 		// prompt UI clients with it.

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -32,7 +32,7 @@ var (
 	promptRequestsCmd = &Command{
 		Path:       "/v2/prompting/requests",
 		GET:        getRequests,
-		ReadAccess: openAccess{},
+		ReadAccess: promptingOpenAccess{},
 		// TODO: make this authenticatedAccess{Polkit: polkitActionPrompting}
 		// Need to add polkitActionPrompting to daemon/api.go and register
 		// prompt UI clients with it.
@@ -42,8 +42,8 @@ var (
 		Path:        "/v2/prompting/requests/{id}",
 		GET:         getRequest,
 		POST:        postRequest,
-		ReadAccess:  openAccess{},
-		WriteAccess: openAccess{},
+		ReadAccess:  promptingOpenAccess{},
+		WriteAccess: promptingOpenAccess{},
 		// TODO: make these authenticatedAccess{Polkit: polkitActionPrompting}
 		// Need to add polkitActionPrompting to daemon/api.go and register
 		// prompt UI clients with it.


### PR DESCRIPTION
snapd-desktop-integration accesses /var/lib/snapd-snap.socket, which requires checks to access. This PR exposes the prompting APIs on this socket, which we can later control access to via a new snapd interface.