### PR TITLE
o/ifacestate/apparmorprompting: clean trailing `/` from paths and path patterns

### DIFF
--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
@@ -303,6 +303,7 @@ func validatePatternOutcomeLifespanDuration(pathPattern string, outcome common.O
 // of the access rule which is returned.  If any of the given parameters are
 // invalid, returns a corresponding error.
 func (ardb *AccessRuleDB) PopulateNewAccessRule(user int, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration int, permissions []common.PermissionType) (*AccessRule, error) {
+	pathPattern = common.StripTrailingSlashes(pathPattern)
 	expiration, err := validatePatternOutcomeLifespanDuration(pathPattern, outcome, lifespan, duration)
 	if err != nil {
 		return nil, err
@@ -423,6 +424,7 @@ func (ardb *AccessRuleDB) RuleWithId(user int, id string) (*AccessRule, error) {
 func (ardb *AccessRuleDB) CreateAccessRule(user int, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration int, permissions []common.PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
+	pathPattern = common.StripTrailingSlashes(pathPattern)
 	newRule, err := ardb.PopulateNewAccessRule(user, snap, app, pathPattern, outcome, lifespan, duration, permissions)
 	if err != nil {
 		return nil, err
@@ -472,6 +474,7 @@ func (ardb *AccessRuleDB) ModifyAccessRule(user int, id string, pathPattern stri
 	if pathPattern == "" {
 		pathPattern = origRule.PathPattern
 	}
+	pathPattern = common.StripTrailingSlashes(pathPattern)
 	if outcome == common.OutcomeUnset {
 		outcome = origRule.Outcome
 	}

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -335,6 +335,21 @@ func GetHighestPrecedencePattern(patterns []string) (string, error) {
 	return shortestPattern, nil
 }
 
+func StripTrailingSlashes(path string) string {
+	for path[len(path)-1] == '/' {
+		path = path[:len(path)-1]
+	}
+	return path
+}
+
 func PathPatternMatches(pathPattern string, path string) (bool, error) {
-	return doublestar.Match(pathPattern, path)
+	path = StripTrailingSlashes(path)
+	matched, err := doublestar.Match(pathPattern, path)
+	if err != nil {
+		return false, err
+	}
+	if matched {
+		return true, nil
+	}
+	return doublestar.Match(pathPattern, path+"/")
 }

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -490,6 +490,59 @@ func (s *commonSuite) TestGetHighestPrecedencePattern(c *C) {
 	c.Check(empty, Equals, "")
 }
 
+func (*commonSuite) TestStripTrailingSlashes(c *C) {
+	cases := []struct {
+		orig     string
+		stripped string
+	}{
+		{
+			"foo",
+			"foo",
+		},
+		{
+			"foo/",
+			"foo",
+		},
+		{
+			"/foo",
+			"/foo",
+		},
+		{
+			"/foo/",
+			"/foo",
+		},
+		{
+			"/foo//",
+			"/foo",
+		},
+		{
+			"/foo///",
+			"/foo",
+		},
+		{
+			"/foo/bar",
+			"/foo/bar",
+		},
+		{
+			"/foo/bar/",
+			"/foo/bar",
+		},
+		{
+			"/foo/bar//",
+			"/foo/bar",
+		},
+		{
+			"/foo/bar///",
+			"/foo/bar",
+		},
+	}
+
+	for _, testCase := range cases {
+		result := common.StripTrailingSlashes(testCase.orig)
+		c.Check(result, Equals, testCase.stripped)
+	}
+}
+
 func (*commonSuite) TestPathPatternMatches(c *C) {
 	cases := []struct {
 		pattern string
@@ -505,6 +558,21 @@ func (*commonSuite) TestPathPatternMatches(c *C) {
 			"/home/test/Documents/foo",
 			"/home/test/Documents/foo.txt",
 			false,
+		},
+		{
+			"/home/test/Documents",
+			"/home/test/Documents",
+			true,
+		},
+		{
+			"/home/test/Documents/*",
+			"/home/test/Documents",
+			true,
+		},
+		{
+			"/home/test/Documents/**",
+			"/home/test/Documents",
+			true,
 		},
 		{
 			"/home/test/Documents/*",


### PR DESCRIPTION
Apparmor requests for access to directories (that is, list the contents of a directory without accessing any of those contents, for example), have trailing `/` characters. Currently, prompt requests are created with the path copied directly from the apparmor request. However, the access rule storage backend does not allow path patterns with trailing `/`. Thus, if a prompt client replies with a path pattern identical to the requested path, it gets an invalid path error.

Additionally, while path `/foo/bar/baz/` is matched by both patterns `/foo/bar/baz/*` and `/foo/bar/baz/**`, the path `/foo/bar/baz` is matched by `/foo/bar/baz/**` but _not_ `/foo/bar/baz/*`. We need to strip trailing `/` characters from path patterns (thus treating patterns as equivalent up to trailing `/`), so I think it best to treat paths as equivalent up to trailing `/` as well.

This change makes the access rule storage strip trailing `/` characters from all path patterns, and makes `/some/file/path/` equivalent to `/some/file/path` when it comes to path matching.

For now, this PR does not strip the trailing `/` from paths in prompt requests, which are sent to the prompt UI. Presumably, it may be useful to the user to see whether the path provided by apparmor has a trailing slash. Thus, all `/` stripping occurs only when matching against rules and when storing path patterns in access rules.