### PR TITLE
prompting: implement follow support via json-seq

### DIFF
--- a/daemon/api_access_control.go
+++ b/daemon/api_access_control.go
@@ -73,9 +73,6 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if err != nil {
 			return BadRequest("invalid value for follow: %q: %v", s, err)
 		}
-		if snap == "" {
-			return BadRequest("follow=true parameter provided, must also provide snap parameter")
-		}
 		follow = f
 	}
 

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -372,7 +372,7 @@ func (fr *followRequestsSeqResponse) ServeHTTP(w http.ResponseWriter, r *http.Re
 	}
 
 	if err != nil && err != io.EOF {
-		writer.WriteByte('\x1E')
+		writer.WriteByte(0x1E) // RS -- see ascii(7), and RFC7464
 		marshalled, _ := json.Marshal(map[string]error{"error": err})
 		writer.Write(marshalled)
 		writer.WriteByte('\n')
@@ -421,7 +421,7 @@ func (fr *followRulesSeqResponse) ServeHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err != nil && err != io.EOF {
-		writer.WriteByte('\x1E')
+		writer.WriteByte(0x1E) // RS -- see ascii(7), and RFC7464
 		marshalled, _ := json.Marshal(map[string]error{"error": err})
 		writer.Write(marshalled)
 		writer.WriteByte('\n')

--- a/daemon/response.go
+++ b/daemon/response.go
@@ -33,6 +33,8 @@ import (
 	"github.com/snapcore/snapd/asserts"
 	"github.com/snapcore/snapd/client"
 	"github.com/snapcore/snapd/logger"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/accessrules"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/promptrequests"
 	"github.com/snapcore/snapd/overlord/restart"
 	"github.com/snapcore/snapd/overlord/snapshotstate"
 	"github.com/snapcore/snapd/overlord/state"
@@ -330,6 +332,104 @@ func (rr *journalLineReaderSeqResponse) ServeHTTP(w http.ResponseWriter, r *http
 		logger.Noticef("cannot stream response; problem writing: %v", err)
 	}
 	rr.Close()
+}
+
+type followRequestsSeqResponse struct {
+	requestsCh chan *promptrequests.PromptRequest
+}
+
+func newFollowRequestsSeqResponse() (*followRequestsSeqResponse, chan *promptrequests.PromptRequest) {
+	resp := &followRequestsSeqResponse{
+		requestsCh: make(chan *promptrequests.PromptRequest, 16),
+	}
+	return resp, resp.requestsCh
+}
+
+func (fr *followRequestsSeqResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json-seq")
+
+	flusher, hasFlusher := w.(http.Flusher)
+
+	var err error
+	writer := bufio.NewWriter(w)
+	enc := json.NewEncoder(writer)
+	for {
+		req, received := <-fr.requestsCh
+		if !received {
+			// requestsCh is closed
+			break
+		}
+		writer.WriteByte(0x1E) // RS -- see ascii(7), and RFC7464
+		if err := enc.Encode(req); err != nil {
+			break
+		}
+		if err := writer.Flush(); err != nil {
+			break
+		}
+		if hasFlusher {
+			flusher.Flush()
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		writer.WriteByte('\x1E')
+		marshalled, _ := json.Marshal(map[string]error{"error": err})
+		writer.Write(marshalled)
+		writer.WriteByte('\n')
+		logger.Noticef("cannot stream response; problem reading: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		logger.Noticef("cannot stream response; problem writing: %v", err)
+	}
+}
+
+type followRulesSeqResponse struct {
+	rulesCh chan *accessrules.AccessRule
+}
+
+func newFollowRulesSeqResponse() (*followRulesSeqResponse, chan *accessrules.AccessRule) {
+	resp := &followRulesSeqResponse{
+		rulesCh: make(chan *accessrules.AccessRule, 16),
+	}
+	return resp, resp.rulesCh
+}
+
+func (fr *followRulesSeqResponse) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json-seq")
+
+	flusher, hasFlusher := w.(http.Flusher)
+
+	var err error
+	writer := bufio.NewWriter(w)
+	enc := json.NewEncoder(writer)
+	for {
+		req, received := <-fr.rulesCh
+		if !received {
+			// rulesCh is closed
+			break
+		}
+		writer.WriteByte(0x1E) // RS -- see ascii(7), and RFC7464
+		if err := enc.Encode(req); err != nil {
+			break
+		}
+		if err := writer.Flush(); err != nil {
+			break
+		}
+		if hasFlusher {
+			flusher.Flush()
+		}
+	}
+
+	if err != nil && err != io.EOF {
+		writer.WriteByte('\x1E')
+		marshalled, _ := json.Marshal(map[string]error{"error": err})
+		writer.Write(marshalled)
+		writer.WriteByte('\n')
+		logger.Noticef("cannot stream response; problem reading: %v", err)
+	}
+	if err := writer.Flush(); err != nil {
+		logger.Noticef("cannot stream response; problem writing: %v", err)
+	}
 }
 
 type assertResponse struct {

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -38,6 +38,7 @@ type snapEntry struct {
 
 type followRuleEntry struct {
 	snapEntries map[string]*snapEntry
+	respWriters map[*FollowRulesSeqResponseWriter]bool
 	lock        sync.Mutex
 }
 
@@ -124,6 +125,7 @@ func (p *Prompting) followRuleEntryForUserOrInit(userId int) *followRuleEntry {
 	if !exists {
 		entry = &followRuleEntry{
 			snapEntries: make(map[string]*snapEntry),
+			respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
 		}
 		p.followRuleEntries[userId] = entry
 	}
@@ -186,29 +188,14 @@ func (p *Prompting) RegisterAndPopulateFollowRulesChan(userId int, snap string, 
 
 	var outstandingRules []*accessrules.AccessRule
 
-	sEntry := entry.snapEntries[snap]
-	if sEntry == nil {
-		sEntry = &snapEntry{
-			respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
-			appEntries:  make(map[string]*appEntry),
-		}
-		entry.snapEntries[snap] = sEntry
-	}
 	// The following is ugly, but while addresses of structs may change,
 	// addresses of entries containing maps should not, so it is safe to
 	// retain those entries, rather than storing their embedded maps in a
 	// common variable.
-	if app != "" {
-		saEntry := sEntry.appEntries[app]
-		if saEntry == nil {
-			saEntry = &appEntry{
-				respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
-			}
-			sEntry.appEntries[app] = saEntry
-		}
-		saEntry.respWriters[respWriter] = true
+	if snap == "" {
+		entry.respWriters[respWriter] = true
 		// Start goroutine to wait until respWriter should be removed
-		// from saEntry.respWriters, either because it has been stopped
+		// from entry.respWriters, either because it has been stopped
 		// or the tomb is dying.
 		p.tomb.Go(func() error {
 			select {
@@ -218,27 +205,61 @@ func (p *Prompting) RegisterAndPopulateFollowRulesChan(userId int, snap string, 
 			}
 			entry.lock.Lock()
 			defer entry.lock.Unlock()
-			delete(saEntry.respWriters, respWriter)
+			delete(entry.respWriters, respWriter)
 			return nil
 		})
-		outstandingRules = p.rules.RulesForSnapApp(userId, snap, app)
+		outstandingRules = p.rules.Rules(userId)
 	} else {
-		sEntry.respWriters[respWriter] = true
-		// Start goroutine to wait until respWriter should be removed
-		// from sEntry.respWriters, either because it has been stopped
-		// or the tomb is dying.
-		p.tomb.Go(func() error {
-			select {
-			case <-p.tomb.Dying():
-				respWriter.Stop()
-			case <-respWriter.Stopping():
+		sEntry := entry.snapEntries[snap]
+		if sEntry == nil {
+			sEntry = &snapEntry{
+				respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
+				appEntries:  make(map[string]*appEntry),
 			}
-			entry.lock.Lock()
-			defer entry.lock.Unlock()
-			delete(sEntry.respWriters, respWriter)
-			return nil
-		})
-		outstandingRules = p.rules.RulesForSnap(userId, snap)
+			entry.snapEntries[snap] = sEntry
+		}
+		if app == "" {
+			sEntry.respWriters[respWriter] = true
+			// Start goroutine to wait until respWriter should be removed
+			// from sEntry.respWriters, either because it has been stopped
+			// or the tomb is dying.
+			p.tomb.Go(func() error {
+				select {
+				case <-p.tomb.Dying():
+					respWriter.Stop()
+				case <-respWriter.Stopping():
+				}
+				entry.lock.Lock()
+				defer entry.lock.Unlock()
+				delete(sEntry.respWriters, respWriter)
+				return nil
+			})
+			outstandingRules = p.rules.RulesForSnap(userId, snap)
+		} else {
+			saEntry := sEntry.appEntries[app]
+			if saEntry == nil {
+				saEntry = &appEntry{
+					respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
+				}
+				sEntry.appEntries[app] = saEntry
+			}
+			saEntry.respWriters[respWriter] = true
+			// Start goroutine to wait until respWriter should be removed
+			// from saEntry.respWriters, either because it has been stopped
+			// or the tomb is dying.
+			p.tomb.Go(func() error {
+				select {
+				case <-p.tomb.Dying():
+					respWriter.Stop()
+				case <-respWriter.Stopping():
+				}
+				entry.lock.Lock()
+				defer entry.lock.Unlock()
+				delete(saEntry.respWriters, respWriter)
+				return nil
+			})
+			outstandingRules = p.rules.RulesForSnapApp(userId, snap, app)
+		}
 	}
 
 	p.tomb.Go(func() error {
@@ -290,6 +311,16 @@ func (p *Prompting) notifyNewRule(userId int, newRule *accessrules.AccessRule) {
 		// initial rules.
 		entry.lock.Lock()
 		defer entry.lock.Unlock()
+
+		for writer := range entry.respWriters {
+			// Don't want to block while holding lock, in case one
+			// of the requestsChan entries is full.
+			p.tomb.Go(func() error {
+				writer.WriteRule(newRule)
+				return nil
+			})
+		}
+
 		sEntry := entry.snapEntries[newRule.Snap]
 		if sEntry == nil {
 			return nil
@@ -302,6 +333,7 @@ func (p *Prompting) notifyNewRule(userId int, newRule *accessrules.AccessRule) {
 				return nil
 			})
 		}
+
 		saEntry := sEntry.appEntries[newRule.App]
 		if saEntry == nil {
 			return nil
@@ -314,6 +346,7 @@ func (p *Prompting) notifyNewRule(userId int, newRule *accessrules.AccessRule) {
 				return nil
 			})
 		}
+
 		return nil
 	})
 }

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -2,6 +2,7 @@ package apparmorprompting
 
 import (
 	"fmt"
+	"sync"
 
 	"gopkg.in/tomb.v2"
 
@@ -21,15 +22,41 @@ type Interface interface {
 	Stop() error
 }
 
+type followReqEntry struct {
+	respWriters map[*FollowRequestsSeqResponseWriter]bool
+	lock        sync.Mutex
+}
+
+type appEntry struct {
+	respWriters map[*FollowRulesSeqResponseWriter]bool
+}
+
+type snapEntry struct {
+	respWriters map[*FollowRulesSeqResponseWriter]bool
+	appEntries  map[string]*appEntry
+}
+
+type followRuleEntry struct {
+	snapEntries map[string]*snapEntry
+	lock        sync.Mutex
+}
+
 type Prompting struct {
-	tomb     tomb.Tomb
-	listener *listener.Listener
-	requests *promptrequests.RequestDB
-	rules    *accessrules.AccessRuleDB
+	tomb              tomb.Tomb
+	listener          *listener.Listener
+	requests          *promptrequests.RequestDB
+	rules             *accessrules.AccessRuleDB
+	followReqEntries  map[int]*followReqEntry
+	followReqLock     sync.Mutex
+	followRuleEntries map[int]*followRuleEntry
+	followRuleLock    sync.Mutex
 }
 
 func New() Interface {
-	p := &Prompting{}
+	p := &Prompting{
+		followReqEntries:  make(map[int]*followReqEntry),
+		followRuleEntries: make(map[int]*followRuleEntry),
+	}
 	return p
 }
 
@@ -57,9 +84,243 @@ func (p *Prompting) disconnect() error {
 	return nil
 }
 
+func (p *Prompting) followReqEntryForUser(userId int) *followReqEntry {
+	p.followReqLock.Lock()
+	defer p.followReqLock.Unlock()
+	entry, exists := p.followReqEntries[userId]
+	if !exists {
+		return nil
+	}
+	return entry
+}
+
+func (p *Prompting) followReqEntryForUserOrInit(userId int) *followReqEntry {
+	p.followReqLock.Lock()
+	defer p.followReqLock.Unlock()
+	entry, exists := p.followReqEntries[userId]
+	if !exists {
+		entry = &followReqEntry{
+			respWriters: make(map[*FollowRequestsSeqResponseWriter]bool),
+		}
+		p.followReqEntries[userId] = entry
+	}
+	return entry
+}
+
+func (p *Prompting) followRuleEntryForUser(userId int) *followRuleEntry {
+	p.followRuleLock.Lock()
+	defer p.followRuleLock.Unlock()
+	entry, exists := p.followRuleEntries[userId]
+	if !exists {
+		return nil
+	}
+	return entry
+}
+
+func (p *Prompting) followRuleEntryForUserOrInit(userId int) *followRuleEntry {
+	p.followRuleLock.Lock()
+	defer p.followRuleLock.Unlock()
+	entry, exists := p.followRuleEntries[userId]
+	if !exists {
+		entry = &followRuleEntry{
+			snapEntries: make(map[string]*snapEntry),
+		}
+		p.followRuleEntries[userId] = entry
+	}
+	return entry
+}
+
+func (p *Prompting) RegisterAndPopulateFollowRequestsChan(userId int, requestsCh chan *promptrequests.PromptRequest) *FollowRequestsSeqResponseWriter {
+	userId = userOverride // TODO: undo this! This is just for debugging
+
+	respWriter := newFollowRequestsSeqResponseWriter(requestsCh)
+
+	entry := p.followReqEntryForUserOrInit(userId)
+
+	entry.lock.Lock()
+	defer entry.lock.Unlock()
+	entry.respWriters[respWriter] = true
+
+	// Start goroutine to wait until respWriter should be removed from
+	// entry.respWriters, either because it has been stopped or the tomb
+	// is dying.
+	p.tomb.Go(func() error {
+		select {
+		case <-p.tomb.Dying():
+			respWriter.Stop()
+		case <-respWriter.Stopping():
+		}
+		entry.lock.Lock()
+		defer entry.lock.Unlock()
+		delete(entry.respWriters, respWriter)
+		return nil
+	})
+
+	// Record current outstanding requests before unlocking.
+	// This way, no new requests (which are sent out independently) can
+	// preempt getting current requests and thus be sent here as well,
+	// causing duplicate requests.
+	outstandingRequests := p.requests.Requests(userId)
+	p.tomb.Go(func() error {
+		// This could block if the chan is filled, so separate goroutine
+		for _, req := range outstandingRequests {
+			if !respWriter.WriteRequest(req) {
+				// respWriter has been stopped
+				break
+			}
+		}
+		return nil
+	})
+	return respWriter
+}
+
+func (p *Prompting) RegisterAndPopulateFollowRulesChan(userId int, snap string, app string, rulesCh chan *accessrules.AccessRule) *FollowRulesSeqResponseWriter {
+	userId = userOverride // TODO: undo this! This is just for debugging
+
+	respWriter := newFollowRulesSeqResponseWriter(rulesCh)
+
+	entry := p.followRuleEntryForUserOrInit(userId)
+
+	entry.lock.Lock()
+	defer entry.lock.Unlock()
+
+	var outstandingRules []*accessrules.AccessRule
+
+	sEntry := entry.snapEntries[snap]
+	if sEntry == nil {
+		sEntry = &snapEntry{
+			respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
+			appEntries:  make(map[string]*appEntry),
+		}
+		entry.snapEntries[snap] = sEntry
+	}
+	// The following is ugly, but while addresses of structs may change,
+	// addresses of entries containing maps should not, so it is safe to
+	// retain those entries, rather than storing their embedded maps in a
+	// common variable.
+	if app != "" {
+		saEntry := sEntry.appEntries[app]
+		if saEntry == nil {
+			saEntry = &appEntry{
+				respWriters: make(map[*FollowRulesSeqResponseWriter]bool),
+			}
+			sEntry.appEntries[app] = saEntry
+		}
+		saEntry.respWriters[respWriter] = true
+		// Start goroutine to wait until respWriter should be removed
+		// from saEntry.respWriters, either because it has been stopped
+		// or the tomb is dying.
+		p.tomb.Go(func() error {
+			select {
+			case <-p.tomb.Dying():
+				respWriter.Stop()
+			case <-respWriter.Stopping():
+			}
+			entry.lock.Lock()
+			defer entry.lock.Unlock()
+			delete(saEntry.respWriters, respWriter)
+			return nil
+		})
+		outstandingRules = p.rules.RulesForSnapApp(userId, snap, app)
+	} else {
+		sEntry.respWriters[respWriter] = true
+		// Start goroutine to wait until respWriter should be removed
+		// from sEntry.respWriters, either because it has been stopped
+		// or the tomb is dying.
+		p.tomb.Go(func() error {
+			select {
+			case <-p.tomb.Dying():
+				respWriter.Stop()
+			case <-respWriter.Stopping():
+			}
+			entry.lock.Lock()
+			defer entry.lock.Unlock()
+			delete(sEntry.respWriters, respWriter)
+			return nil
+		})
+		outstandingRules = p.rules.RulesForSnap(userId, snap)
+	}
+
+	p.tomb.Go(func() error {
+		// This could block if the chan is filled, so separate goroutine
+		for _, req := range outstandingRules {
+			if !respWriter.WriteRule(req) {
+				// respWriter has been stopped
+				break
+			}
+		}
+		return nil
+	})
+	return respWriter
+}
+
+// Notify all open connections for requests with the given userId that a new
+// request has been received.
+func (p *Prompting) notifyNewRequest(userId int, newRequest *promptrequests.PromptRequest) {
+	p.tomb.Go(func() error {
+		entry := p.followReqEntryForUser(userId)
+		if entry == nil {
+			return nil
+		}
+		// Lock so that new incoming request is not mixed in with the
+		// initial outstanding requests.
+		entry.lock.Lock()
+		defer entry.lock.Unlock()
+		for writer := range entry.respWriters {
+			// Don't want to block while holding lock, in case one
+			// of the requestsChan entries is full.
+			p.tomb.Go(func() error {
+				writer.WriteRequest(newRequest)
+				return nil
+			})
+		}
+		return nil
+	})
+}
+
+// Notify all open connections for rules with the given userId that a new
+// rule has been received.
+func (p *Prompting) notifyNewRule(userId int, newRule *accessrules.AccessRule) {
+	p.tomb.Go(func() error {
+		entry := p.followRuleEntryForUser(userId)
+		if entry == nil {
+			return nil
+		}
+		// Lock so that new incoming rule are not mixed in with the
+		// initial rules.
+		entry.lock.Lock()
+		defer entry.lock.Unlock()
+		sEntry := entry.snapEntries[newRule.Snap]
+		if sEntry == nil {
+			return nil
+		}
+		for writer := range sEntry.respWriters {
+			// Don't want to block while holding lock, in case one
+			// of the requestsChan entries is full.
+			p.tomb.Go(func() error {
+				writer.WriteRule(newRule)
+				return nil
+			})
+		}
+		saEntry := sEntry.appEntries[newRule.App]
+		if saEntry == nil {
+			return nil
+		}
+		for writer := range saEntry.respWriters {
+			// Don't want to block while holding lock, in case one
+			// of the requestsChan entries is full.
+			p.tomb.Go(func() error {
+				writer.WriteRule(newRule)
+				return nil
+			})
+		}
+		return nil
+	})
+}
+
 func (p *Prompting) handleListenerReq(req *listener.Request) error {
-	// user := int(req.SubjectUid) // TODO: undo this! This is just for debugging
-	user := userOverride // TODO: undo this! This is just for debugging
+	// userId := int(req.SubjectUid) // TODO: undo this! This is just for debugging
+	userId := userOverride // TODO: undo this! This is just for debugging
 	snap, app, err := common.LabelToSnapApp(req.Label)
 	if err != nil {
 		// the triggering process is not a snap, so treat apparmor label as both snap and app fields
@@ -74,7 +335,7 @@ func (p *Prompting) handleListenerReq(req *listener.Request) error {
 
 	satisfiedPerms := make([]common.PermissionType, 0, len(permissions))
 	for _, perm := range permissions {
-		if yesNo, err := p.rules.IsPathAllowed(user, snap, app, path, perm); err == nil {
+		if yesNo, err := p.rules.IsPathAllowed(userId, snap, app, path, perm); err == nil {
 			if !yesNo {
 				req.YesNo <- false
 				// TODO: the response puts all original permissions in the
@@ -91,9 +352,10 @@ func (p *Prompting) handleListenerReq(req *listener.Request) error {
 		return nil
 	}
 
-	p.requests.Add(user, snap, app, path, permissions, req.YesNo)
-	logger.Noticef("adding request to internal storage: user: %v, snap: %v, app: %v, path: %v, permissions: %v", user, snap, app, path, permissions)
-	// TODO: notify any listeners to the requests API using p.tomb.Go()
+	newRequest := p.requests.Add(userId, snap, app, path, permissions, req.YesNo)
+	logger.Noticef("adding request to internal storage: %+v", newRequest)
+
+	p.notifyNewRequest(userId, newRequest)
 	return nil
 }
 
@@ -179,6 +441,7 @@ func (p *Prompting) PostRequest(userId int, requestId string, reply *PromptReply
 		// CreateAccessRule (CreateAccessRuleFromReply ?)
 		return nil, err
 	}
+	p.notifyNewRule(userId, newRule)
 
 	// Apply new rule to outstanding prompt requests.
 	satisfiedReqIds, err := p.requests.HandleNewRule(userId, newRule.Snap, newRule.App, newRule.PathPattern, newRule.Outcome, newRule.Permissions)
@@ -256,6 +519,7 @@ func (p *Prompting) PostRulesCreate(userId int, rules []*PostRulesCreateRuleCont
 		} else {
 			createdRules = append(createdRules, newRule)
 		}
+		p.notifyNewRule(userId, newRule)
 	}
 	if len(errors) > 0 {
 		err := fmt.Errorf("")

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
@@ -18,7 +18,7 @@ type PromptRequest struct {
 	App         string                  `json:"app"`
 	Path        string                  `json:"path"`
 	Permissions []common.PermissionType `json:"permissions"`
-	replyChan   chan bool
+	replyChan   chan bool               `json:"-"`
 }
 
 type userRequestDB struct {

--- a/overlord/ifacestate/apparmorprompting/responses.go
+++ b/overlord/ifacestate/apparmorprompting/responses.go
@@ -1,0 +1,190 @@
+package apparmorprompting
+
+import (
+	"sync"
+
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/accessrules"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/promptrequests"
+)
+
+type FollowRequestsSeqResponseWriter struct {
+	requestsCh      chan *promptrequests.PromptRequest
+	stoppingCh      chan interface{} // Should only ever be closed by Stop().
+	stoppingChMutex sync.Mutex       // Prevent stoppingCh from being closed twice.
+	writeWG         sync.WaitGroup
+	writeWGMutex    sync.Mutex
+}
+
+func newFollowRequestsSeqResponseWriter(requestsCh chan *promptrequests.PromptRequest) *FollowRequestsSeqResponseWriter {
+	rw := &FollowRequestsSeqResponseWriter{
+		requestsCh: requestsCh,
+		stoppingCh: make(chan interface{}),
+	}
+	return rw
+}
+
+// WriteRequest writes the given prompt request to the response data channel.
+// If the response writer has already been stopped, do not write anything.
+// Returns true if the write was completed successfully, else false.
+func (rw *FollowRequestsSeqResponseWriter) WriteRequest(req *promptrequests.PromptRequest) bool {
+	rw.writeWGMutex.Lock()
+	rw.writeWG.Add(1)
+	rw.writeWGMutex.Unlock()
+	defer rw.writeWG.Done()
+
+	// If rw.stoppingCh has already been closed, return immediately.
+	// Don't try to write to rw.requestsCh, because if rw.stoppingCh was
+	// closed before this function began, then rw.requestsCh may already be
+	// closed, and writing to it would result in a panic.
+	select {
+	case <-rw.stoppingCh:
+		return false
+	default:
+	}
+
+	// Once here, we know that rw.stoppingCh was not closed at the start of
+	// this function call. Thus, it is safe to write to rw.requestsCh,
+	// since we called rw.writeWG.Add(1), and Stop() cannot close before
+	// rw.writeWG.Wait() returns. Attempt to write to rw.requestsCh.
+	// If rw.stoppingCh closes while blocked on the write, return.
+	select {
+	case <-rw.stoppingCh:
+		return false
+	case rw.requestsCh <- req:
+		return true
+	}
+}
+
+// Close stoppingCh for the given FollowRequestsSeqResponseWriter if it has not
+// yet been closed. Returns true if it was already closed, else returns false.
+func (rw *FollowRequestsSeqResponseWriter) closeStoppingChAlready() bool {
+	rw.stoppingChMutex.Lock()
+	defer rw.stoppingChMutex.Unlock()
+	select {
+	case <-rw.stoppingCh:
+		return true
+	default:
+	}
+	close(rw.stoppingCh)
+	return false
+}
+
+// Stop tells the writer to close rw.stoppingCh, and thus to stop accepting
+// new writes. Stop() should be the only place rw.stoppingCh can be closed.
+// If rw.stoppingCh has already been closed, this indicates Stop() has already
+// been called, so return immediately.
+func (rw *FollowRequestsSeqResponseWriter) Stop() {
+	if rw.closeStoppingChAlready() {
+		return
+	}
+
+	// XXX: what if current goroutine terminates before closing rw.requestsCh?
+	// Will this spawned goroutine never exit?
+	go func() {
+		for range rw.requestsCh {
+			// Consume entries until rw.requestsCh closes
+		}
+	}()
+
+	rw.writeWGMutex.Lock()
+	rw.writeWG.Wait()
+	rw.writeWGMutex.Unlock()
+
+	close(rw.requestsCh)
+}
+
+// Stopping returns a channel on which reads block until Stop() has been called.
+func (rw *FollowRequestsSeqResponseWriter) Stopping() chan interface{} {
+	return rw.stoppingCh
+}
+
+type FollowRulesSeqResponseWriter struct {
+	rulesCh         chan *accessrules.AccessRule
+	stoppingCh      chan interface{} // Should only ever be closed by Stop().
+	stoppingChMutex sync.Mutex       // Prevent stoppingCh from being closed twice.
+	writeWG         sync.WaitGroup
+	writeWGMutex    sync.Mutex
+}
+
+func newFollowRulesSeqResponseWriter(rulesCh chan *accessrules.AccessRule) *FollowRulesSeqResponseWriter {
+	rw := &FollowRulesSeqResponseWriter{
+		rulesCh:    rulesCh,
+		stoppingCh: make(chan interface{}),
+	}
+	return rw
+}
+
+// WriteRequest writes the given access rule to the response data channel.
+// If the response writer has already been stopped, do not write anything.
+// Returns true if the write was completed successfully, else false.
+func (rw *FollowRulesSeqResponseWriter) WriteRule(rule *accessrules.AccessRule) bool {
+	rw.writeWGMutex.Lock()
+	rw.writeWG.Add(1)
+	rw.writeWGMutex.Unlock()
+	defer rw.writeWG.Done()
+
+	// If rw.stoppingCh has already been closed, return immediately.
+	// Don't try to write to rw.rulesCh, because if rw.stoppingCh was
+	// closed before this function began, then rw.rulesCh may already be
+	// closed, and writing to it would result in a panic.
+	select {
+	case <-rw.stoppingCh:
+		return false
+	default:
+	}
+
+	// Once here, we know that rw.stoppingCh was not closed at the start of
+	// this function call. Thus, it is safe to write to rw.rulesCh,
+	// since we called rw.writeWG.Add(1), and Stop() cannot close before
+	// rw.writeWG.Wait() returns. Attempt to write to rw.rulesCh.
+	// If rw.stoppingCh closes while blocked on the write, return.
+	select {
+	case <-rw.stoppingCh:
+		return false
+	case rw.rulesCh <- rule:
+		return true
+	}
+}
+
+// Close stoppingCh for the given FollowRulesSeqResponseWriter if it has not
+// yet been closed. Returns true if it was already closed, else returns false.
+func (rw *FollowRulesSeqResponseWriter) closeStoppingChAlready() bool {
+	rw.stoppingChMutex.Lock()
+	defer rw.stoppingChMutex.Unlock()
+	select {
+	case <-rw.stoppingCh:
+		return true
+	default:
+	}
+	close(rw.stoppingCh)
+	return false
+}
+
+// Stop tells the writer to close rw.stoppingCh, and thus to stop accepting
+// new writes. Stop() should be the only place rw.stoppingCh can be closed.
+// If rw.stoppingCh has already been closed, this indicates Stop() has already
+// been called, so return immediately.
+func (rw *FollowRulesSeqResponseWriter) Stop() {
+	if rw.closeStoppingChAlready() {
+		return
+	}
+
+	// XXX: what if current goroutine terminates before closing rw.rulesCh?
+	// Will this spawned goroutine never exit?
+	go func() {
+		for range rw.rulesCh {
+			// Consume entries until rw.rulesCh closes
+		}
+	}()
+
+	rw.writeWGMutex.Lock()
+	rw.writeWG.Wait()
+	rw.writeWGMutex.Unlock()
+
+	close(rw.rulesCh)
+}
+
+// Stopping returns a channel on which reads block until Stop() has been called.
+func (rw *FollowRulesSeqResponseWriter) Stopping() chan interface{} {
+	return rw.stoppingCh
+}

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -129,7 +129,7 @@ func Register() (*Listener, error) {
 	return listener, nil
 }
 
-func (l *Listener) decodeAndDispatchRequest(buf []byte, tomb *tomb.Tomb) error {
+func (l *Listener) decodeAndDispatchRequest(buf []byte, t *tomb.Tomb) error {
 	var nmsg notify.MsgNotification
 	if err := nmsg.UnmarshalBinary(buf); err != nil {
 		return err
@@ -151,10 +151,7 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte, tomb *tomb.Tomb) error {
 			// log.Printf("notification request: %#v\n", fmsg)
 			req := newRequest(l, &fmsg)
 			l.R <- req
-			tomb.Go(func() error {
-				l.waitAndRespond(req, &fmsg)
-				return nil
-			})
+			l.waitAndRespond(req, &fmsg, t)
 		default:
 			return fmt.Errorf("unsupported mediation class: %v", omsg.Class)
 		}
@@ -164,25 +161,36 @@ func (l *Listener) decodeAndDispatchRequest(buf []byte, tomb *tomb.Tomb) error {
 	return nil
 }
 
-func (l *Listener) waitAndRespond(req *Request, msg *notify.MsgNotificationFile) {
-	resp := notify.ResponseForRequest(&msg.MsgNotification)
-	resp.MsgNotification.Error = 0 // ignored in responses
-	resp.MsgNotification.NoCache = 1
-	if allow := <-req.YesNo; allow {
-		resp.Allow = msg.Allow | msg.Deny
-		resp.Deny = 0
-		resp.Error = 0
-	} else {
-		resp.Allow = 0
-		resp.Deny = msg.Deny
-		resp.Error = msg.Error
-		// msg.Error is field from MsgNotificationResponse, and is unused.
-		// msg.MsgNotification.Error is also ignored in responses.
-	}
-	//log.Printf("notification response: %#v\n", resp)
-	if err := l.encodeAndSendResponse(&resp); err != nil {
-		l.fail(err)
-	}
+func (l *Listener) waitAndRespond(req *Request, msg *notify.MsgNotificationFile, t *tomb.Tomb) {
+	t.Go(func() error {
+		resp := notify.ResponseForRequest(&msg.MsgNotification)
+		resp.MsgNotification.Error = 0 // ignored in responses
+		resp.MsgNotification.NoCache = 1
+		var allow bool
+		select {
+		case a := <-req.YesNo:
+			allow = a
+		case <-t.Dying():
+			// Deny all requests when tomb is dying
+			allow = false
+		}
+		if allow {
+			resp.Allow = msg.Allow | msg.Deny
+			resp.Deny = 0
+			resp.Error = 0
+		} else {
+			resp.Allow = 0
+			resp.Deny = msg.Deny
+			resp.Error = msg.Error
+			// msg.Error is field from MsgNotificationResponse, and is unused.
+			// msg.MsgNotification.Error is also ignored in responses.
+		}
+		//log.Printf("notification response: %#v\n", resp)
+		if err := l.encodeAndSendResponse(&resp); err != nil {
+			l.fail(err)
+		}
+		return nil
+	})
 }
 
 func (l *Listener) encodeAndSendResponse(resp *notify.MsgNotificationResponse) error {
@@ -195,7 +203,7 @@ func (l *Listener) encodeAndSendResponse(resp *notify.MsgNotificationResponse) e
 	return err
 }
 
-func (l *Listener) runOnce(tomb *tomb.Tomb) error {
+func (l *Listener) runOnce(t *tomb.Tomb) error {
 	// XXX: Wait must return immediately once epoll is closed.
 	events, err := l.poll.Wait()
 	if err != nil {
@@ -214,7 +222,7 @@ func (l *Listener) runOnce(tomb *tomb.Tomb) error {
 				if err != nil {
 					return err
 				}
-				if err := l.decodeAndDispatchRequest(buf, tomb); err != nil {
+				if err := l.decodeAndDispatchRequest(buf, t); err != nil {
 					return err
 				}
 			}
@@ -224,10 +232,10 @@ func (l *Listener) runOnce(tomb *tomb.Tomb) error {
 }
 
 // Run reads and dispatches kernel requests until stopped.
-func (l *Listener) Run(tomb *tomb.Tomb) {
+func (l *Listener) Run(t *tomb.Tomb) {
 	// TODO: allow the run to stop
 	for {
-		if err := l.runOnce(tomb); err != nil {
+		if err := l.runOnce(t); err != nil {
 			l.fail(err)
 			break
 		}


### PR DESCRIPTION
This PR implements the `follow=true` query parameter for `GET /v2/prompting/requests` and `GET /v2/access-control/rules`. HTTP responses with type `"json-seq"` are returned by these endpoints.

There is some complexity regarding the channels used to communicate new requests/rules from the prompting backend to the open json-seq responses. In particular, how those channels can be safely closed, since new goroutines are spawned in response to the creation of new requests/rules, and those goroutines need to write to the open channels, and should not be responsible for closing them (importantly, go panics if close is called on the same channel more than once). See `overlord/ifacestate/apparmorprompting/responses.go` for the approach to solving those problems.

I would appreciate any suggestions, including about naming and organization, as the usage of subpackages of `overlord/ifacestate` is new in the daemon, the naming of the new `responses.go` file is questionable, and the near-identical code between `followRequestsSeqResponse` and `followRulesSeqResponse` (and accompanying `FollowR{equest,ule}sSeqResponseWriter`s) could benefit from some code deduplication, if possible. I long for Rust's generics.