### PR TITLE
o/ifacestate/apparmorprompting: handle lifespan "single"

### DIFF
--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -166,6 +166,10 @@ func (p *Prompting) PostRequest(userId int, requestId string, reply *PromptReply
 		return nil, err
 	}
 
+	if reply.Lifespan == common.LifespanSingle {
+		return make([]string, 0), nil
+	}
+
 	// Create new rule based on the reply.
 	newRule, err := p.rules.CreateAccessRule(userId, req.Snap, req.App, reply.PathPattern, reply.Outcome, reply.Lifespan, reply.Duration, reply.Permissions)
 	if err != nil {


### PR DESCRIPTION
A reply with a lifespan of "single" should not create a new access rule.

Previously, such a reply created an access rule with a lifespan of "single", which then expired after being used to satisfy one future request.  This was done to match the behaviour of creating a new access rule with a lifepan of "single" directly by posting to the `/v2/access-control/rules` endpoint with an action of "create".

Both as the result of a reply and of a direct rule creation, the idea of a rule with a lifespan of "single" is a bit strange.  In the latter case, we may as well support this behaviour.  In the former, however, I think that the use in satisfying the corresponding request counts as the "single" use for which a reply with a lifespan of "single" applies.