### PR TITLE
prompting: Don't require polkit access for snap-prompting-control

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -40,7 +40,7 @@ var (
 		GET:         getRequest,
 		POST:        postRequest,
 		ReadAccess:  interfaceOpenAccess{Interface: "snap-prompting-control"},
-		WriteAccess: interfaceAuthenticatedAccess{Interface: "snap-prompting-control", Polkit: polkitActionManage},
+		WriteAccess: interfaceOpenAccess{Interface: "snap-prompting-control"},
 	}
 )
 


### PR DESCRIPTION
Only snaps that are allowed to perform prompting will have this interface connected. They will provide their own prompting and don't require polkit to confirm.
