### PR TITLE
interfaces: Allow snap-prompting-control interface access to snap metadata

### DIFF
--- a/daemon/api_find.go
+++ b/daemon/api_find.go
@@ -40,7 +40,7 @@ var (
 	findCmd = &Command{
 		Path:       "/v2/find",
 		GET:        searchStore,
-		ReadAccess: openAccess{},
+		ReadAccess: interfaceOpenAccess{"snap-prompting-control"},
 	}
 )
 

--- a/daemon/api_find_test.go
+++ b/daemon/api_find_test.go
@@ -29,6 +29,7 @@ import (
 	"gopkg.in/check.v1"
 
 	"github.com/snapcore/snapd/client"
+	"github.com/snapcore/snapd/daemon"
 	"github.com/snapcore/snapd/httputil"
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/snapstate"
@@ -40,6 +41,12 @@ var _ = check.Suite(&findSuite{})
 
 type findSuite struct {
 	apiBaseSuite
+}
+
+func (s *findSuite) SetUpTest(c *check.C) {
+	s.apiBaseSuite.SetUpTest(c)
+
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-prompting-control"})
 }
 
 func (s *findSuite) TestFind(c *check.C) {

--- a/daemon/api_snaps.go
+++ b/daemon/api_snaps.go
@@ -51,7 +51,7 @@ var (
 		Path:        "/v2/snaps/{name}",
 		GET:         getSnapInfo,
 		POST:        postSnap,
-		ReadAccess:  openAccess{},
+		ReadAccess:  interfaceOpenAccess{"snap-prompting-control"},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 
@@ -59,7 +59,7 @@ var (
 		Path:        "/v2/snaps",
 		GET:         getSnapsInfo,
 		POST:        postSnaps,
-		ReadAccess:  openAccess{},
+		ReadAccess:  interfaceOpenAccess{"snap-prompting-control"},
 		WriteAccess: authenticatedAccess{Polkit: polkitActionManage},
 	}
 )

--- a/daemon/api_snaps_test.go
+++ b/daemon/api_snaps_test.go
@@ -65,6 +65,7 @@ var _ = check.Suite(&snapsSuite{})
 func (s *snapsSuite) SetUpTest(c *check.C) {
 	s.apiBaseSuite.SetUpTest(c)
 
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interface: "snap-prompting-control"})
 	s.expectWriteAccess(daemon.AuthenticatedAccess{Polkit: "io.snapcraft.snapd.manage"})
 }
 


### PR DESCRIPTION
This is needed for snapd-desktop-integration to show the appropriate icon, title, publisher info for snaps. Originally proposed [directly into snapd](https://github.com/snapcore/snapd/pull/13143), but it seems to make more sense as part of the prompting interface.