### PR TITLE
prompting: handle duplicate kernel requests

### DIFF
--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -385,7 +385,12 @@ func (p *Prompting) handleListenerReq(req *listener.Request) error {
 		return nil
 	}
 
-	newRequest := p.requests.Add(userId, snap, app, path, permissions, req.YesNo)
+	newRequest, merged := p.requests.AddOrMerge(userId, snap, app, path, permissions, req.YesNo)
+	if merged {
+		logger.Noticef("new request merged with identical existing request: %+v", newRequest)
+		return nil
+	}
+
 	logger.Noticef("adding request to internal storage: %+v", newRequest)
 
 	p.notifyNewRequest(userId, newRequest)

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
@@ -2,6 +2,7 @@ package promptrequests
 
 import (
 	"errors"
+	"reflect"
 	"sync"
 
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
@@ -18,7 +19,7 @@ type PromptRequest struct {
 	App         string                  `json:"app"`
 	Path        string                  `json:"path"`
 	Permissions []common.PermissionType `json:"permissions"`
-	replyChan   chan bool               `json:"-"`
+	replyChans  []chan bool             `json:"-"`
 }
 
 type userRequestDB struct {
@@ -37,7 +38,13 @@ func New() *RequestDB {
 }
 
 // Creates, adds, and returns a new prompt request from the given parameters.
-func (rdb *RequestDB) Add(user int, snap string, app string, path string, permissions []common.PermissionType, replyChan chan bool) *PromptRequest {
+//
+// If the parameters exactly match an existing request, merge it with that
+// existing request instead, and do not add a new request. If a new request was
+// added, returns the new request and false, indicating the request was not
+// merged. If it was merged with an identical existing request, returns the
+// existing request and true.
+func (rdb *RequestDB) AddOrMerge(user int, snap string, app string, path string, permissions []common.PermissionType, replyChan chan bool) (*PromptRequest, bool) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	userEntry, exists := rdb.PerUser[user]
@@ -47,6 +54,15 @@ func (rdb *RequestDB) Add(user int, snap string, app string, path string, permis
 		}
 		userEntry = rdb.PerUser[user]
 	}
+
+	// Search for an identical existing request, merge if found
+	for _, req := range userEntry.ById {
+		if req.Snap == snap && req.App == app && req.Path == path && reflect.DeepEqual(req.Permissions, permissions) {
+			req.replyChans = append(req.replyChans, replyChan)
+			return req, true
+		}
+	}
+
 	id, timestamp := common.NewIdAndTimestamp()
 	req := &PromptRequest{
 		Id:          id,
@@ -55,10 +71,10 @@ func (rdb *RequestDB) Add(user int, snap string, app string, path string, permis
 		App:         app,
 		Path:        path,
 		Permissions: permissions, // TODO: copy permissions list?
-		replyChan:   replyChan,
+		replyChans:  []chan bool{replyChan},
 	}
 	userEntry.ById[id] = req
-	return req
+	return req, false
 }
 
 func (rdb *RequestDB) Requests(user int) []*PromptRequest {
@@ -110,7 +126,9 @@ func (rdb *RequestDB) Reply(user int, id string, outcome common.OutcomeType) (*P
 	default:
 		return nil, common.ErrInvalidOutcome
 	}
-	req.replyChan <- outcomeBool
+	for _, replyChan := range req.replyChans {
+		replyChan <- outcomeBool
+	}
 	delete(userEntry.ById, id)
 	return req, nil
 }
@@ -156,7 +174,9 @@ func (rdb *RequestDB) HandleNewRule(user int, snap string, app string, pathPatte
 			continue
 		}
 		// all permissions of request satisfied
-		req.replyChan <- outcomeBool
+		for _, replyChan := range req.replyChans {
+			replyChan <- outcomeBool
+		}
 		delete(userEntry.ById, id)
 		satisfiedReqIds = append(satisfiedReqIds, id)
 	}

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
@@ -58,11 +58,11 @@ func (s *promptrequestsSuite) TestAddRequests(c *C) {
 
 	stored = rdb.Requests(user)
 	c.Assert(stored, HasLen, 1)
-	c.Assert(stored[0], DeepEquals, req)
+	c.Assert(stored[0], Equals, req)
 
 	storedReq, err := rdb.RequestWithId(user, req.Id)
 	c.Assert(err, IsNil)
-	c.Assert(storedReq, DeepEquals, req)
+	c.Assert(storedReq, Equals, req)
 }
 
 func (s *promptrequestsSuite) TestRequestWithIdErrors(c *C) {
@@ -78,7 +78,7 @@ func (s *promptrequestsSuite) TestRequestWithIdErrors(c *C) {
 
 	result, err := rdb.RequestWithId(user, req.Id)
 	c.Assert(err, IsNil)
-	c.Assert(result, DeepEquals, req)
+	c.Assert(result, Equals, req)
 
 	result, err = rdb.RequestWithId(user, "foo")
 	c.Assert(err, Equals, promptrequests.ErrRequestIdNotFound)
@@ -256,30 +256,30 @@ func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	stored := rdb.Requests(user)
 	c.Assert(stored, HasLen, 1)
-	c.Assert(stored[0], DeepEquals, req)
+	c.Assert(stored[0], Equals, req)
 
 	satisfied, err := rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherPattern, badOutcome, permissions)
+	c.Assert(err, Equals, common.ErrInvalidOutcome)
+	c.Assert(satisfied, HasLen, 0)
+
+	satisfied, err = rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Assert(satisfied, HasLen, 0)
 
-	satisfied, err = rdb.HandleNewRule(user, otherSnap, otherApp, otherPattern, badOutcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, otherSnap, otherApp, otherPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Assert(satisfied, HasLen, 0)
 
-	satisfied, err = rdb.HandleNewRule(user, snap, otherApp, otherPattern, badOutcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, otherApp, otherPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Assert(satisfied, HasLen, 0)
 
-	satisfied, err = rdb.HandleNewRule(user, snap, app, otherPattern, badOutcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, otherPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Assert(satisfied, HasLen, 0)
 
-	satisfied, err = rdb.HandleNewRule(user, snap, app, badPattern, badOutcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, badPattern, outcome, permissions)
 	c.Assert(err, ErrorMatches, "syntax error in pattern")
-	c.Assert(satisfied, HasLen, 0)
-
-	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, badOutcome, permissions)
-	c.Assert(err, IsNil)
 	c.Assert(satisfied, HasLen, 0)
 
 	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)


### PR DESCRIPTION
Sometimes, multiple duplicate access requests arrive from the kernel as the result of a single user-facing operation. This results in multiple prompts for the user, and when the user replies to one, it satisfies the other internally. Ideally, the client is notified that the remaining prompt has been satisfied, but nonetheless, this is unintuitive for users and results in visual clutter.

This PR solves the issue by checking each new request from the kernel against existing requests, and if one is entirely identical (user, snap, app, path pattern, permissions), then it merges with that existing request.

This is done at the `apparmorprompting` package level, as opposed to the `listener` package, as the mechanism for replying to messages from the kernel is to spin up a new goroutine waiting on a boolean value over the reply channel, and send the message once that is complete. A separate response must be sent for each request from the kernel, so there is no easy way to add a new request onto an existing response goroutine which is waiting. This does not mean that the listener could not be re-architected to merge identical requests, it would just likely mean moving the original request information out of a goroutine and into data associated with the listener instance, which is fairly undesirable.