### PR TITLE
prompting: correctly handle the UID of requests to prompting endpoints

### DIFF
--- a/daemon/api_access_control.go
+++ b/daemon/api_access_control.go
@@ -89,16 +89,16 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		// close it.
 		jsonSeqResp, rulesCh := newFollowRulesSeqResponse()
 		// TODO: implement the following:
-		// respWriter := c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRulesChan(int(ucred.Uid), snap, app, rulesCh)
+		// respWriter := c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRulesChan(ucred.Uid, snap, app, rulesCh)
 		// When daemon stops, call respWriter.Stop()
-		_ = c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRulesChan(int(ucred.Uid), snap, app, rulesCh)
+		_ = c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRulesChan(ucred.Uid, snap, app, rulesCh)
 		return jsonSeqResp
 	}
 
 	if app != "" && snap == "" {
 		return BadRequest("app parameter provided, must also provide snap parameter")
 	}
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(int(ucred.Uid), snap, app)
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, app)
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -124,7 +124,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	switch postBody.Action {
 	case "create":
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesCreate(int(ucred.Uid), postBody.CreateRules)
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesCreate(ucred.Uid, postBody.CreateRules)
 		if err != nil {
 			return InternalError("%v", err)
 		}
@@ -136,7 +136,7 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 				return BadRequest(`must include "snap" parameter in "selectors"`)
 			}
 		}
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesDelete(int(ucred.Uid), postBody.DeleteSelectors)
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesDelete(ucred.Uid, postBody.DeleteSelectors)
 		if err != nil {
 			return InternalError("%v", err)
 		}
@@ -159,7 +159,7 @@ func getRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		return Forbidden("cannot get remote user: %v", err)
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRule(int(ucred.Uid), id)
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRule(ucred.Uid, id)
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -188,13 +188,13 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	switch postBody.Action {
 	case "modify":
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleModify(int(ucred.Uid), id, postBody.Rule)
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleModify(ucred.Uid, id, postBody.Rule)
 		if err != nil {
 			return InternalError("%v", err)
 		}
 		return SyncResponse(result)
 	case "delete":
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleDelete(int(ucred.Uid), id)
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleDelete(ucred.Uid, id)
 		if err != nil {
 			return InternalError("%v", err)
 		}

--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -83,13 +83,13 @@ func getRequests(c *Command, r *http.Request, user *auth.UserState) Response {
 		// close it.
 		jsonSeqResp, requestsCh := newFollowRequestsSeqResponse()
 		// TODO: implement the following:
-		// respWriter := c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRequestsChan(int(ucred.Uid), requestsCh)
+		// respWriter := c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRequestsChan(ucred.Uid, requestsCh)
 		// When daemon stops, call respWriter.Stop()
-		_ = c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRequestsChan(int(ucred.Uid), requestsCh)
+		_ = c.d.overlord.InterfaceManager().Prompting().RegisterAndPopulateFollowRequestsChan(ucred.Uid, requestsCh)
 		return jsonSeqResp
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRequests(int(ucred.Uid))
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRequests(ucred.Uid)
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -110,7 +110,7 @@ func getRequest(c *Command, r *http.Request, user *auth.UserState) Response {
 		return Forbidden("cannot get remote user: %v", err)
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRequest(int(ucred.Uid), id)
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRequest(ucred.Uid, id)
 	if err != nil {
 		return InternalError("%v", err)
 	}
@@ -137,7 +137,7 @@ func postRequest(c *Command, r *http.Request, user *auth.UserState) Response {
 		return BadRequest("cannot decode request body into prompt reply: %v", err)
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().PostRequest(int(ucred.Uid), id, &reply)
+	result, err := c.d.overlord.InterfaceManager().Prompting().PostRequest(ucred.Uid, id, &reply)
 	if err != nil {
 		return InternalError("%v", err)
 	}

--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
@@ -27,7 +27,7 @@ var ErrUserNotAllowed = errors.New("the given user is not allowed to access the 
 type AccessRule struct {
 	Id          string                  `json:"id"`
 	Timestamp   string                  `json:"timestamp"`
-	User        int                     `json:"user"`
+	User        uint32                  `json:"user"`
 	Snap        string                  `json:"snap"`
 	App         string                  `json:"app"`
 	PathPattern string                  `json:"path-pattern"`
@@ -71,7 +71,7 @@ type userDB struct {
 
 type AccessRuleDB struct {
 	ById    map[string]*AccessRule
-	PerUser map[int]*userDB
+	PerUser map[uint32]*userDB
 	mutex   sync.Mutex
 }
 
@@ -80,7 +80,7 @@ type AccessRuleDB struct {
 func New() (*AccessRuleDB, error) {
 	ardb := &AccessRuleDB{
 		ById:    make(map[string]*AccessRule),
-		PerUser: make(map[int]*userDB),
+		PerUser: make(map[uint32]*userDB),
 	}
 	return ardb, ardb.load()
 }
@@ -89,7 +89,7 @@ func (ardb *AccessRuleDB) dbpath() string {
 	return filepath.Join(dirs.SnapdStateDir(dirs.GlobalRootDir), "access-rules.json")
 }
 
-func (ardb *AccessRuleDB) permissionDBForUserSnapAppPermission(user int, snap string, app string, permission common.PermissionType) *permissionDB {
+func (ardb *AccessRuleDB) permissionDBForUserSnapAppPermission(user uint32, snap string, app string, permission common.PermissionType) *permissionDB {
 	userSnaps := ardb.PerUser[user]
 	if userSnaps == nil {
 		userSnaps = &userDB{
@@ -216,7 +216,7 @@ func (ardb *AccessRuleDB) RefreshTreeEnforceConsistency() {
 	defer ardb.mutex.Unlock()
 	needToSave := false
 	newById := make(map[string]*AccessRule)
-	ardb.PerUser = make(map[int]*userDB)
+	ardb.PerUser = make(map[uint32]*userDB)
 	for id, rule := range ardb.ById {
 		err, conflictingId, conflictingPermission := ardb.addRuleToTree(rule)
 		for err != nil {
@@ -302,7 +302,7 @@ func validatePatternOutcomeLifespanDuration(pathPattern string, outcome common.O
 // time, to compute the expiration time for the rule, and stores that as part
 // of the access rule which is returned.  If any of the given parameters are
 // invalid, returns a corresponding error.
-func (ardb *AccessRuleDB) PopulateNewAccessRule(user int, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) PopulateNewAccessRule(user uint32, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
 	pathPattern = common.StripTrailingSlashes(pathPattern)
 	expiration, err := validatePatternOutcomeLifespanDuration(pathPattern, outcome, lifespan, duration)
 	if err != nil {
@@ -329,7 +329,7 @@ func (ardb *AccessRuleDB) PopulateNewAccessRule(user int, snap string, app strin
 // Checks whether the given path with the given permission is allowed or
 // denied by existing access rules for the given user, snap, and app.  If no
 // access rule applies, returns ErrNoMatchingRule.
-func (ardb *AccessRuleDB) IsPathAllowed(user int, snap string, app string, path string, permission common.PermissionType) (bool, error) {
+func (ardb *AccessRuleDB) IsPathAllowed(user uint32, snap string, app string, path string, permission common.PermissionType) (bool, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	needToSave := false
@@ -397,7 +397,7 @@ func (ardb *AccessRuleDB) IsPathAllowed(user int, snap string, app string, path 
 	}
 }
 
-func (ardb *AccessRuleDB) ruleWithIdInternal(user int, id string) (*AccessRule, error) {
+func (ardb *AccessRuleDB) ruleWithIdInternal(user uint32, id string) (*AccessRule, error) {
 	rule, exists := ardb.ById[id]
 	if !exists {
 		return nil, ErrRuleIdNotFound
@@ -411,7 +411,7 @@ func (ardb *AccessRuleDB) ruleWithIdInternal(user int, id string) (*AccessRule, 
 // Returns the rule with the given ID.
 // If the rule is not found, returns ErrRuleNotFound.
 // If the rule does not apply to the given user, returns ErrUserNotAllowed.
-func (ardb *AccessRuleDB) RuleWithId(user int, id string) (*AccessRule, error) {
+func (ardb *AccessRuleDB) RuleWithId(user uint32, id string) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	return ardb.ruleWithIdInternal(user, id)
@@ -421,7 +421,7 @@ func (ardb *AccessRuleDB) RuleWithId(user int, id string) (*AccessRule, error) {
 // database.  If any of the given parameters are invalid, returns an error.
 // Otherwise, returns the newly-created access rule, and saves the database to
 // disk.
-func (ardb *AccessRuleDB) CreateAccessRule(user int, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	pathPattern = common.StripTrailingSlashes(pathPattern)
@@ -440,7 +440,7 @@ func (ardb *AccessRuleDB) CreateAccessRule(user int, snap string, app string, pa
 // Removes the access rule with the given ID from the rules database.  If the
 // rule does not apply to the given user, returns ErrUserNotAllowed.  If
 // successful, saves the database to disk.
-func (ardb *AccessRuleDB) DeleteAccessRule(user int, id string) (*AccessRule, error) {
+func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	rule, err := ardb.ruleWithIdInternal(user, id)
@@ -464,7 +464,7 @@ func (ardb *AccessRuleDB) DeleteAccessRule(user int, id string) (*AccessRule, er
 // modified rule to the database, rolls back to the previous unmodified rule,
 // leaving the database unchanged.  If the database is changed, it is saved to
 // disk.
-func (ardb *AccessRuleDB) ModifyAccessRule(user int, id string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
+func (ardb *AccessRuleDB) ModifyAccessRule(user uint32, id string, pathPattern string, outcome common.OutcomeType, lifespan common.LifespanType, duration string, permissions []common.PermissionType) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	origRule, err := ardb.ruleWithIdInternal(user, id)
@@ -509,7 +509,7 @@ func (ardb *AccessRuleDB) ModifyAccessRule(user int, id string, pathPattern stri
 }
 
 // Returns all access rules which apply to the given user.
-func (ardb *AccessRuleDB) Rules(user int) []*AccessRule {
+func (ardb *AccessRuleDB) Rules(user uint32) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)
@@ -522,7 +522,7 @@ func (ardb *AccessRuleDB) Rules(user int) []*AccessRule {
 }
 
 // Returns all access rules which apply to the given user and the given snap.
-func (ardb *AccessRuleDB) RulesForSnap(user int, snap string) []*AccessRule {
+func (ardb *AccessRuleDB) RulesForSnap(user uint32, snap string) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)
@@ -535,7 +535,7 @@ func (ardb *AccessRuleDB) RulesForSnap(user int, snap string) []*AccessRule {
 }
 
 // Returns all access rules which apply to the given user, snap, and app.
-func (ardb *AccessRuleDB) RulesForSnapApp(user int, snap string, app string) []*AccessRule {
+func (ardb *AccessRuleDB) RulesForSnapApp(user uint32, snap string, app string) []*AccessRule {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	rules := make([]*AccessRule, 0)

--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules_test.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules_test.go
@@ -29,7 +29,7 @@ func (s *accessruleSuite) SetUpTest(c *C) {
 func (s *accessruleSuite) TestPopulateNewAccessRule(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	outcome := common.OutcomeAllow
@@ -72,7 +72,7 @@ func (s *accessruleSuite) TestPopulateNewAccessRule(c *C) {
 func (s *accessruleSuite) TestCreateDeleteAccessRuleSimple(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -146,7 +146,7 @@ func (s *accessruleSuite) TestCreateDeleteAccessRuleSimple(c *C) {
 func (s *accessruleSuite) TestCreateAccessRuleUnhappy(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -178,7 +178,7 @@ func (s *accessruleSuite) TestCreateAccessRuleUnhappy(c *C) {
 func (s *accessruleSuite) TestModifyAccessRule(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -252,7 +252,7 @@ func (s *accessruleSuite) TestModifyAccessRule(c *C) {
 func (s *accessruleSuite) TestRuleWithId(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -285,7 +285,7 @@ func (s *accessruleSuite) TestRuleWithId(c *C) {
 func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -331,7 +331,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencySimple(c *C) {
 func (s *accessruleSuite) TestRefreshTreeEnforceConsistencyComplex(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -432,7 +432,7 @@ func (s *accessruleSuite) TestRefreshTreeEnforceConsistencyComplex(c *C) {
 func (s *accessruleSuite) TestNewSaveLoad(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"
@@ -460,7 +460,7 @@ func (s *accessruleSuite) TestNewSaveLoad(c *C) {
 func (s *accessruleSuite) TestIsPathAllowed(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	lifespan := common.LifespanForever
@@ -530,7 +530,7 @@ func (s *accessruleSuite) TestIsPathAllowed(c *C) {
 func (s *accessruleSuite) TestRuleExpiration(c *C) {
 	ardb, _ := accessrules.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	permissions := []common.PermissionType{
@@ -600,7 +600,7 @@ func (s *accessruleSuite) TestRuleExpiration(c *C) {
 func (s *accessruleSuite) TestRulesLookup(c *C) {
 	ardb, _ := accessrules.New()
 
-	var origUser int = 1000
+	var origUser uint32 = 1000
 	snap := "lxd"
 	app := "lxc"
 	pathPattern := "/home/test/Documents/**"

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -14,8 +14,6 @@ import (
 	"github.com/snapcore/snapd/sandbox/apparmor/notify/listener"
 )
 
-var userOverride int = 1234
-
 type Interface interface {
 	Connect() error
 	Run() error
@@ -133,8 +131,6 @@ func (p *Prompting) followRuleEntryForUserOrInit(userId int) *followRuleEntry {
 }
 
 func (p *Prompting) RegisterAndPopulateFollowRequestsChan(userId int, requestsCh chan *promptrequests.PromptRequest) *FollowRequestsSeqResponseWriter {
-	userId = userOverride // TODO: undo this! This is just for debugging
-
 	respWriter := newFollowRequestsSeqResponseWriter(requestsCh)
 
 	entry := p.followReqEntryForUserOrInit(userId)
@@ -177,8 +173,6 @@ func (p *Prompting) RegisterAndPopulateFollowRequestsChan(userId int, requestsCh
 }
 
 func (p *Prompting) RegisterAndPopulateFollowRulesChan(userId int, snap string, app string, rulesCh chan *accessrules.AccessRule) *FollowRulesSeqResponseWriter {
-	userId = userOverride // TODO: undo this! This is just for debugging
-
 	respWriter := newFollowRulesSeqResponseWriter(rulesCh)
 
 	entry := p.followRuleEntryForUserOrInit(userId)
@@ -352,8 +346,7 @@ func (p *Prompting) notifyNewRule(userId int, newRule *accessrules.AccessRule) {
 }
 
 func (p *Prompting) handleListenerReq(req *listener.Request) error {
-	// userId := int(req.SubjectUid) // TODO: undo this! This is just for debugging
-	userId := userOverride // TODO: undo this! This is just for debugging
+	userId := int(req.SubjectUid)
 	snap, app, err := common.LabelToSnapApp(req.Label)
 	if err != nil {
 		// the triggering process is not a snap, so treat apparmor label as both snap and app fields
@@ -442,13 +435,11 @@ func (p *Prompting) Stop() error {
 }
 
 func (p *Prompting) GetRequests(userId int) ([]*promptrequests.PromptRequest, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	reqs := p.requests.Requests(userId)
 	return reqs, nil
 }
 
 func (p *Prompting) GetRequest(userId int, requestId string) (*promptrequests.PromptRequest, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	req, err := p.requests.RequestWithId(userId, requestId)
 	return req, err
 }
@@ -462,7 +453,6 @@ type PromptReply struct {
 }
 
 func (p *Prompting) PostRequest(userId int, requestId string, reply *PromptReply) ([]string, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	req, err := p.requests.Reply(userId, requestId, reply.Outcome)
 	if err != nil {
 		return nil, err
@@ -545,7 +535,6 @@ type PostRuleRequestBody struct {
 }
 
 func (p *Prompting) GetRules(userId int, snap string, app string) ([]*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	// Daemon already checked that if app != "", then snap != ""
 	if app != "" {
 		rules := p.rules.RulesForSnapApp(userId, snap, app)
@@ -560,7 +549,6 @@ func (p *Prompting) GetRules(userId int, snap string, app string) ([]*accessrule
 }
 
 func (p *Prompting) PostRulesCreate(userId int, rules []*PostRulesCreateRuleContents) ([]*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	createdRules := make([]*accessrules.AccessRule, 0, len(rules))
 	errors := make([]error, 0)
 	for _, ruleContents := range rules {
@@ -595,7 +583,6 @@ func (p *Prompting) PostRulesCreate(userId int, rules []*PostRulesCreateRuleCont
 }
 
 func (p *Prompting) PostRulesDelete(userId int, deleteSelectors []*PostRulesDeleteSelectors) ([]*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	deletedRules := make([]*accessrules.AccessRule, 0)
 	for _, selector := range deleteSelectors {
 		snap := selector.Snap
@@ -619,13 +606,11 @@ func (p *Prompting) PostRulesDelete(userId int, deleteSelectors []*PostRulesDele
 }
 
 func (p *Prompting) GetRule(userId int, ruleId string) (*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	rule, err := p.rules.RuleWithId(userId, ruleId)
 	return rule, err
 }
 
 func (p *Prompting) PostRuleModify(userId int, ruleId string, contents *PostRuleModifyRuleContents) (*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	pathPattern := contents.PathPattern
 	outcome := contents.Outcome
 	lifespan := contents.Lifespan
@@ -636,7 +621,6 @@ func (p *Prompting) PostRuleModify(userId int, ruleId string, contents *PostRule
 }
 
 func (p *Prompting) PostRuleDelete(userId int, ruleId string) (*accessrules.AccessRule, error) {
-	userId = userOverride // TODO: undo this! This is just for debugging
 	rule, err := p.rules.DeleteAccessRule(userId, ruleId)
 	return rule, err
 }

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests.go
@@ -27,13 +27,13 @@ type userRequestDB struct {
 }
 
 type RequestDB struct {
-	PerUser map[int]*userRequestDB
+	PerUser map[uint32]*userRequestDB
 	mutex   sync.Mutex
 }
 
 func New() *RequestDB {
 	return &RequestDB{
-		PerUser: make(map[int]*userRequestDB),
+		PerUser: make(map[uint32]*userRequestDB),
 	}
 }
 
@@ -44,7 +44,7 @@ func New() *RequestDB {
 // added, returns the new request and false, indicating the request was not
 // merged. If it was merged with an identical existing request, returns the
 // existing request and true.
-func (rdb *RequestDB) AddOrMerge(user int, snap string, app string, path string, permissions []common.PermissionType, replyChan chan bool) (*PromptRequest, bool) {
+func (rdb *RequestDB) AddOrMerge(user uint32, snap string, app string, path string, permissions []common.PermissionType, replyChan chan bool) (*PromptRequest, bool) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	userEntry, exists := rdb.PerUser[user]
@@ -77,7 +77,7 @@ func (rdb *RequestDB) AddOrMerge(user int, snap string, app string, path string,
 	return req, false
 }
 
-func (rdb *RequestDB) Requests(user int) []*PromptRequest {
+func (rdb *RequestDB) Requests(user uint32) []*PromptRequest {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	userEntry, exists := rdb.PerUser[user]
@@ -91,7 +91,7 @@ func (rdb *RequestDB) Requests(user int) []*PromptRequest {
 	return requests
 }
 
-func (rdb *RequestDB) RequestWithId(user int, id string) (*PromptRequest, error) {
+func (rdb *RequestDB) RequestWithId(user uint32, id string) (*PromptRequest, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	userEntry, exists := rdb.PerUser[user]
@@ -106,7 +106,7 @@ func (rdb *RequestDB) RequestWithId(user int, id string) (*PromptRequest, error)
 }
 
 // Reply resolves the request with the given ID using the given outcome.
-func (rdb *RequestDB) Reply(user int, id string, outcome common.OutcomeType) (*PromptRequest, error) {
+func (rdb *RequestDB) Reply(user uint32, id string, outcome common.OutcomeType) (*PromptRequest, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	userEntry, exists := rdb.PerUser[user]
@@ -135,7 +135,7 @@ func (rdb *RequestDB) Reply(user int, id string, outcome common.OutcomeType) (*P
 
 // If any existing requests are satisfied by the given rule, send the decision
 // along their respective channels, and return their IDs.
-func (rdb *RequestDB) HandleNewRule(user int, snap string, app string, pathPattern string, outcome common.OutcomeType, permissions []common.PermissionType) ([]string, error) {
+func (rdb *RequestDB) HandleNewRule(user uint32, snap string, app string, pathPattern string, outcome common.OutcomeType, permissions []common.PermissionType) ([]string, error) {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	var outcomeBool bool

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
@@ -32,7 +32,7 @@ func (s *promptrequestsSuite) TestNew(c *C) {
 
 func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 	rdb := promptrequests.New()
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -78,7 +78,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 
 func (s *promptrequestsSuite) TestRequestWithIdErrors(c *C) {
 	rdb := promptrequests.New()
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -103,7 +103,7 @@ func (s *promptrequestsSuite) TestRequestWithIdErrors(c *C) {
 
 func (s *promptrequestsSuite) TestReply(c *C) {
 	rdb := promptrequests.New()
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -142,7 +142,7 @@ func (s *promptrequestsSuite) TestReply(c *C) {
 
 func (s *promptrequestsSuite) TestReplyErrors(c *C) {
 	rdb := promptrequests.New()
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -164,7 +164,7 @@ func (s *promptrequestsSuite) TestReplyErrors(c *C) {
 func (s *promptrequestsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	rdb := promptrequests.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -214,7 +214,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	rdb := promptrequests.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"
@@ -272,7 +272,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
 	rdb := promptrequests.New()
 
-	var user int = 1000
+	var user uint32 = 1000
 	snap := "nextcloud"
 	app := "occ"
 	path := "/home/test/Documents/foo.txt"


### PR DESCRIPTION
This removes the workaround which overrode the UID of requests to prompting and access control API endpoints. Now, these use `ucrednet` to parse the request UID from the request `RemoteAddr`. Requests to the API endpoints should only be able to access prompt requests and access rules which correspond to their UID.

This also switches to using `uint32` to store UIDs throughout the prompting infrastructure, as `int` cannot represent all `uint32` values when run on 32-bit systems.