### PR TITLE
daemon,o/ifacestate/apparmorprompting,s/apparmor/notify/listener: add interface to requests and rules

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -145,6 +145,7 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	snap := query.Get("snap")
 	app := query.Get("app")
+	iface := query.Get("interface")
 
 	ucred, err := ucrednetGet(r.RemoteAddr)
 	if err != nil {
@@ -154,7 +155,10 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 	if app != "" && snap == "" {
 		return BadRequest("app parameter provided, must also provide snap parameter")
 	}
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, app)
+	if iface != "" && snap == "" {
+		return BadRequest("interface parameter provided, must also provide snap parameter")
+	}
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, app, iface)
 	if err != nil {
 		return InternalError("%v", err)
 	}

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -69,29 +69,6 @@ const (
 	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
 )
 
-// Removes the given permission from the given list of permissions.
-// Returns a new list with all instances of the given permission removed.
-// If the given permission is not found in the list, returns an error, along
-// with the original list.
-func RemovePermissionFromList(list []PermissionType, permission PermissionType) ([]PermissionType, error) {
-	if len(list) == 0 {
-		return list, ErrPermissionNotInList
-	}
-	newList := make([]PermissionType, 0, len(list)-1)
-	found := false
-	for _, perm := range list {
-		if perm == permission {
-			found = true
-			continue
-		}
-		newList = append(newList, perm)
-	}
-	if !found {
-		return list, ErrPermissionNotInList
-	}
-	return newList, nil
-}
-
 // Converts the given timestamp string to a time.Time in Local time.
 // The timestamp string is expected to be of the format time.RFC3999Nano.
 // If it cannot be parsed as such, returns an error.
@@ -225,6 +202,29 @@ func PermissionsListContains(list []PermissionType, permission PermissionType) b
 		}
 	}
 	return false
+}
+
+// Removes the given permission from the given list of permissions.
+// Returns a new list with all instances of the given permission removed.
+// If the given permission is not found in the list, returns an error, along
+// with the original list.
+func RemovePermissionFromList(list []PermissionType, permission PermissionType) ([]PermissionType, error) {
+	if len(list) == 0 {
+		return list, ErrPermissionNotInList
+	}
+	newList := make([]PermissionType, 0, len(list)-1)
+	found := false
+	for _, perm := range list {
+		if perm == permission {
+			found = true
+			continue
+		}
+		newList = append(newList, perm)
+	}
+	if !found {
+		return list, ErrPermissionNotInList
+	}
+	return newList, nil
 }
 
 var allowablePathPatternRegexp = regexp.MustCompile(`^(/|(/[^/*{}]+)*(/\*|(/\*\*)?(/\*\.[^/*{}]+)?)?)$`)

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -104,6 +104,22 @@ func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
 	}
 }
 
+func (s *commonSuite) TestSelectSingleInterface(c *C) {
+	defaultInterface := "other"
+	fakeIface := "foo"
+	c.Check(common.SelectSingleInterface([]string{}), Equals, defaultInterface, Commentf("input: []string{}"))
+	c.Check(common.SelectSingleInterface([]string{""}), Equals, defaultInterface, Commentf(`input: []string{""}`))
+	c.Check(common.SelectSingleInterface([]string{fakeIface}), Equals, defaultInterface, Commentf(`input: []string{""}`))
+	for iface := range common.InterfacePriorities {
+		c.Check(common.SelectSingleInterface([]string{iface}), Equals, iface)
+		fakeList := []string{iface, fakeIface}
+		c.Check(common.SelectSingleInterface(fakeList), Equals, iface)
+		fakeList = []string{fakeIface, iface}
+		c.Check(common.SelectSingleInterface(fakeList), Equals, iface)
+	}
+	c.Check(common.SelectSingleInterface([]string{"home", "camera", "foo"}), Equals, "home")
+}
+
 func (s *commonSuite) TestPermissionMaskToPermissionsList(c *C) {
 	cases := []struct {
 		mask notify.FilePermission

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -26,63 +26,6 @@ func (s *commonSuite) SetUpTest(c *C) {
 	dirs.SetRootDir(s.tmpdir)
 }
 
-func (s *commonSuite) TestRemovePermissionFromList(c *C) {
-	cases := []struct {
-		initial []common.PermissionType
-		remove  common.PermissionType
-		final   []common.PermissionType
-		err     error
-	}{
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
-			common.PermissionRead,
-			[]common.PermissionType{common.PermissionWrite, common.PermissionExecute},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
-			common.PermissionWrite,
-			[]common.PermissionType{common.PermissionRead, common.PermissionExecute},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
-			common.PermissionExecute,
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionRead},
-			common.PermissionRead,
-			[]common.PermissionType{common.PermissionWrite},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead},
-			common.PermissionRead,
-			[]common.PermissionType{},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionRead},
-			common.PermissionRead,
-			[]common.PermissionType{},
-			nil,
-		},
-		{
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
-			common.PermissionAppend,
-			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
-			common.ErrPermissionNotInList,
-		},
-	}
-	for _, testCase := range cases {
-		result, err := common.RemovePermissionFromList(testCase.initial, testCase.remove)
-		c.Assert(err, Equals, testCase.err)
-		c.Assert(result, DeepEquals, testCase.final)
-	}
-}
-
 func (s *commonSuite) TestTimestamps(c *C) {
 	before := time.Now()
 	ts := common.CurrentTimestamp()
@@ -298,6 +241,63 @@ func (s *commonSuite) TestPermissionsListContains(c *C) {
 		common.PermissionChangeGroup,
 	} {
 		c.Check(common.PermissionsListContains(permissionsList, perm), Equals, false)
+	}
+}
+
+func (s *commonSuite) TestRemovePermissionFromList(c *C) {
+	cases := []struct {
+		initial []common.PermissionType
+		remove  common.PermissionType
+		final   []common.PermissionType
+		err     error
+	}{
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionRead,
+			[]common.PermissionType{common.PermissionWrite, common.PermissionExecute},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionWrite,
+			[]common.PermissionType{common.PermissionRead, common.PermissionExecute},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionExecute,
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{common.PermissionWrite},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionRead},
+			common.PermissionRead,
+			[]common.PermissionType{},
+			nil,
+		},
+		{
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.PermissionAppend,
+			[]common.PermissionType{common.PermissionRead, common.PermissionWrite, common.PermissionExecute},
+			common.ErrPermissionNotInList,
+		},
+	}
+	for _, testCase := range cases {
+		result, err := common.RemovePermissionFromList(testCase.initial, testCase.remove)
+		c.Assert(err, Equals, testCase.err)
+		c.Assert(result, DeepEquals, testCase.final)
 	}
 }
 

--- a/overlord/ifacestate/apparmorprompting/common/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package common
+
+var InterfacePriorities = interfacePriorities

--- a/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
+++ b/overlord/ifacestate/apparmorprompting/promptrequests/promptrequests_test.go
@@ -55,6 +55,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 	rdb := promptrequests.New(notifyRequest)
 	snap := "nextcloud"
 	app := "occ"
+	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 
@@ -66,7 +67,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 	c.Assert(stored, HasLen, 0)
 
 	before := time.Now()
-	req1, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq1)
+	req1, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
 	after := time.Now()
 	c.Assert(merged, Equals, false)
 
@@ -74,7 +75,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 	c.Check(requestNoticeIDs[0], Equals, req1.ID)
 	requestNoticeIDs = requestNoticeIDs[1:]
 
-	req2, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq2)
+	req2, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
 	c.Assert(merged, Equals, true)
 	c.Assert(req2, Equals, req1)
 
@@ -88,6 +89,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 
 	c.Check(req1.Snap, Equals, snap)
 	c.Check(req1.App, Equals, app)
+	c.Check(req1.Interface, Equals, iface)
 	c.Check(req1.Path, Equals, path)
 	c.Check(req1.Permissions, DeepEquals, permissions)
 
@@ -102,7 +104,7 @@ func (s *promptrequestsSuite) TestAddOrMergeRequests(c *C) {
 	// Looking up request should not trigger notice
 	c.Assert(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	req3, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq3)
+	req3, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, true)
 	c.Check(req3, Equals, req1)
 
@@ -128,12 +130,13 @@ func (s *promptrequestsSuite) TestRequestWithIDErrors(c *C) {
 	rdb := promptrequests.New(notifyRequest)
 	snap := "nextcloud"
 	app := "occ"
+	iface := "system-files"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 
 	listenerReq := &listener.Request{}
 
-	req, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq)
+	req, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 1, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
@@ -177,20 +180,21 @@ func (s *promptrequestsSuite) TestReply(c *C) {
 	rdb := promptrequests.New(notifyRequest)
 	snap := "nextcloud"
 	app := "occ"
+	iface := "personal-files"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 
 	listenerReq1 := &listener.Request{}
 	listenerReq2 := &listener.Request{}
 
-	req1, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq1)
+	req1, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 1, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 	c.Check(requestNoticeIDs[0], Equals, req1.ID)
 	requestNoticeIDs = requestNoticeIDs[1:]
 
-	req2, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq2)
+	req2, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, true)
 	c.Check(req2, Equals, req1)
 
@@ -216,14 +220,14 @@ func (s *promptrequestsSuite) TestReply(c *C) {
 	listenerReq1 = &listener.Request{}
 	listenerReq2 = &listener.Request{}
 
-	req1, merged = rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq1)
+	req1, merged = rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 1, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 	c.Check(requestNoticeIDs[0], Equals, req1.ID)
 	requestNoticeIDs = requestNoticeIDs[1:]
 
-	req2, merged = rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq2)
+	req2, merged = rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, true)
 	c.Check(req2, Equals, req1)
 
@@ -266,12 +270,13 @@ func (s *promptrequestsSuite) TestReplyErrors(c *C) {
 	rdb := promptrequests.New(notifyRequest)
 	snap := "nextcloud"
 	app := "occ"
+	iface := "removable-media"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 
 	listenerReq := &listener.Request{}
 
-	req, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq)
+	req, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 1, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
@@ -318,26 +323,27 @@ func (s *promptrequestsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 
 	snap := "nextcloud"
 	app := "occ"
+	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 	listenerReq1 := &listener.Request{}
-	req1, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq1)
+	req1, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead}
 	listenerReq2 := &listener.Request{}
-	req2, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq2)
+	req2, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionRead}
 	listenerReq3 := &listener.Request{}
-	req3, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq3)
+	req3, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionOpen}
 	listenerReq4 := &listener.Request{}
-	req4, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq4)
+	req4, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 4, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
@@ -354,7 +360,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	outcome := common.OutcomeAllow
 	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead, common.PermissionAppend}
 
-	satisfied, err := rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	satisfied, err := rdb.HandleNewRule(user, snap, app, iface, pathPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 2)
 	c.Check(strutil.ListContains(satisfied, req2.ID), Equals, true)
@@ -405,26 +411,27 @@ func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 
 	snap := "nextcloud"
 	app := "occ"
+	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 
 	permissions := []common.PermissionType{common.PermissionExecute, common.PermissionWrite, common.PermissionRead}
 	listenerReq1 := &listener.Request{}
-	req1, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq1)
+	req1, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead}
 	listenerReq2 := &listener.Request{}
-	req2, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq2)
+	req2, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionRead}
 	listenerReq3 := &listener.Request{}
-	req3, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq3)
+	req3, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, false)
 
 	permissions = []common.PermissionType{common.PermissionOpen}
 	listenerReq4 := &listener.Request{}
-	req4, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq4)
+	req4, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 4, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
@@ -441,7 +448,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	outcome := common.OutcomeDeny
 	permissions = []common.PermissionType{common.PermissionWrite, common.PermissionRead, common.PermissionAppend}
 
-	satisfied, err := rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	satisfied, err := rdb.HandleNewRule(user, snap, app, iface, pathPattern, outcome, permissions)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 2)
 	c.Check(strutil.ListContains(satisfied, req2.ID), Equals, true)
@@ -472,7 +479,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	// check that denying the final missing permission does not deny the whole rule.
 	// TODO: change this behaviour?
 	permissions = []common.PermissionType{common.PermissionExecute}
-	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, iface, pathPattern, outcome, permissions)
 
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
@@ -504,10 +511,11 @@ func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	snap := "nextcloud"
 	app := "occ"
+	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []common.PermissionType{common.PermissionRead}
 	listenerReq := &listener.Request{}
-	req, merged := rdb.AddOrMerge(user, snap, app, path, permissions, listenerReq)
+	req, merged := rdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(requestNoticeIDs, HasLen, 1, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
@@ -520,6 +528,7 @@ func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
 	otherUser := user + 1
 	otherSnap := "ldx"
 	otherApp := "lxc"
+	otherInterface := "system-files"
 	otherPattern := "/home/test/Pictures/**.png"
 	badPattern := "\\home\\test\\"
 	badOutcome := common.OutcomeType("foo")
@@ -528,43 +537,49 @@ func (s *promptrequestsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Assert(stored, HasLen, 1)
 	c.Assert(stored[0], Equals, req)
 
-	satisfied, err := rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherPattern, badOutcome, permissions)
+	satisfied, err := rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherInterface, otherPattern, badOutcome, permissions)
 	c.Check(err, Equals, common.ErrInvalidOutcome)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(otherUser, otherSnap, otherApp, otherInterface, otherPattern, outcome, permissions)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(user, otherSnap, otherApp, otherPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, otherSnap, otherApp, otherInterface, otherPattern, outcome, permissions)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(user, snap, otherApp, otherPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, otherApp, otherInterface, otherPattern, outcome, permissions)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(user, snap, app, otherPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, otherInterface, otherPattern, outcome, permissions)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(user, snap, app, badPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, iface, otherPattern, outcome, permissions)
+	c.Check(err, IsNil)
+	c.Check(satisfied, HasLen, 0)
+
+	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
+
+	satisfied, err = rdb.HandleNewRule(user, snap, app, iface, badPattern, outcome, permissions)
 	c.Check(err, ErrorMatches, "syntax error in pattern")
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(requestNoticeIDs, HasLen, 0, Commentf("requestNoticeIDs: %v; rdb.PerUser[%d]: %+v", requestNoticeIDs, user, rdb.PerUser[user]))
 
-	satisfied, err = rdb.HandleNewRule(user, snap, app, pathPattern, outcome, permissions)
+	satisfied, err = rdb.HandleNewRule(user, snap, app, iface, pathPattern, outcome, permissions)
 	c.Check(err, IsNil)
 	c.Assert(satisfied, HasLen, 1)
 

--- a/sandbox/apparmor/notify/listener/listener.go
+++ b/sandbox/apparmor/notify/listener/listener.go
@@ -65,6 +65,9 @@ type Request struct {
 	pid uint32
 	// label is the apparmor label on the process which triggered the request.
 	label string
+	// interfaces is the list of snapd interface associated with the apparmor
+	// rules which triggered the request.
+	interfaces []string
 	// subjectUID is the UID of the subject which triggered the request.
 	subjectUID uint32
 
@@ -92,9 +95,11 @@ func newRequest(msg *notify.MsgNotificationFile) (*Request, error) {
 	default:
 		return nil, fmt.Errorf("unsupported mediation class: %v", msg.Class)
 	}
+	interfaces := []string{"home"} // TODO: set according to tag included in msg
 	return &Request{
 		pid:        msg.Pid,
 		label:      msg.Label,
+		interfaces: interfaces,
 		subjectUID: msg.SUID,
 
 		path:       msg.Name,
@@ -113,6 +118,12 @@ func (r *Request) PID() uint32 {
 // Label returns the apparmor label on the process which triggered the request.
 func (r *Request) Label() string {
 	return r.label
+}
+
+// Interface returns the list of snapd interfaces associated with the apparmor
+// rules which triggered the request.
+func (r *Request) Interfaces() []string {
+	return r.interfaces
 }
 
 // SubjectUID returns the UID of the subject which triggered the request.

--- a/sandbox/apparmor/notify/listener/listener_test.go
+++ b/sandbox/apparmor/notify/listener/listener_test.go
@@ -277,6 +277,7 @@ func (*listenerSuite) TestRunSimple(c *C) {
 		case req := <-l.Reqs():
 			c.Assert(req.PID(), Equals, msg.Pid)
 			c.Assert(req.Label(), Equals, label)
+			c.Assert(req.Interfaces(), DeepEquals, []string{"home"}) // TODO: implement actual interface in message tag
 			c.Assert(req.SubjectUID(), Equals, msg.SUID)
 			c.Assert(req.Path(), Equals, path)
 			c.Assert(req.Class(), Equals, notify.AA_CLASS_FILE)


### PR DESCRIPTION
This PR adds a field for the interface associated with requests and rules. When a request is sent by the kernel, message tagging can be used to include the snapd interface(s) associated with the apparmor rule(s) which triggered the request. The listener then parses the interface(s) from the message and includes them in the request. For now, however, the "home" interface is hardcoded as a placeholder until message tagging is enabled in the kernel and snapd.

The prompting manager then decides which of the interfaces included in the listener request has priority, and uses that one for prompt requests and any rules which are created in association with the listener request.

This PR also adds differentiation between rules based on their interface. That is, rules associated with one interface do not apply to requests coming in from a different interface. 