### PR TITLE
daemon,o/i/apparmorprompting: replaced delete terminology with remove

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -189,20 +189,20 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 			return InternalError("%v", err)
 		}
 		return SyncResponse(result)
-	case "delete":
-		for _, selector := range postBody.DeleteSelectors {
+	case "remove":
+		for _, selector := range postBody.RemoveSelectors {
 			snap := selector.Snap
 			if snap == "" {
 				return BadRequest(`must include "snap" parameter in "selectors"`)
 			}
 		}
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesDelete(ucred.Uid, postBody.DeleteSelectors)
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesRemove(ucred.Uid, postBody.RemoveSelectors)
 		if err != nil {
 			return InternalError("%v", err)
 		}
 		return SyncResponse(result)
 	default:
-		return BadRequest(`action must "create" or "delete"`)
+		return BadRequest(`action must "create" or "remove"`)
 	}
 }
 
@@ -253,13 +253,13 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 			return InternalError("%v", err)
 		}
 		return SyncResponse(result)
-	case "delete":
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleDelete(ucred.Uid, id)
+	case "remove":
+		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleRemove(ucred.Uid, id)
 		if err != nil {
 			return InternalError("%v", err)
 		}
 		return SyncResponse(result)
 	default:
-		return BadRequest(`action must be "create" or "delete"`)
+		return BadRequest(`action must be "create" or "remove"`)
 	}
 }

--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules.go
@@ -240,7 +240,7 @@ func getNewerRule(id1 string, ts1 string, id2 string, ts2 string) string {
 // This function is only required if database is left inconsistent (should not
 // occur) or when loading, in case the stored rules on disk were corrupted.
 //
-// By default, issues a notice for each rule which is modified or deleted as a
+// By default, issues a notice for each rule which is modified or removed as a
 // result of a conflict with another rule. If notifyEveryRule is true, issues
 // a notice for every rule which was in the database prior to the beginning of
 // the function. In either case, at most one notice is issued for each rule.
@@ -510,7 +510,7 @@ func (ardb *AccessRuleDB) CreateAccessRule(user uint32, snap string, app string,
 // Removes the access rule with the given ID from the rules database.  If the
 // rule does not apply to the given user, returns ErrUserNotAllowed.  If
 // successful, saves the database to disk.
-func (ardb *AccessRuleDB) DeleteAccessRule(user uint32, id string) (*AccessRule, error) {
+func (ardb *AccessRuleDB) RemoveAccessRule(user uint32, id string) (*AccessRule, error) {
 	ardb.mutex.Lock()
 	defer ardb.mutex.Unlock()
 	rule, err := ardb.ruleWithIDInternal(user, id)

--- a/overlord/ifacestate/apparmorprompting/accessrules/accessrules_test.go
+++ b/overlord/ifacestate/apparmorprompting/accessrules/accessrules_test.go
@@ -76,7 +76,7 @@ func (s *accessruleSuite) TestPopulateNewAccessRule(c *C) {
 	}
 }
 
-func (s *accessruleSuite) TestCreateDeleteAccessRuleSimple(c *C) {
+func (s *accessruleSuite) TestCreateRemoveAccessRuleSimple(c *C) {
 	var user uint32 = 1000
 	ruleNoticeIDs := make([]string, 0, 2)
 	notifyRule := func(userID uint32, ruleID string, options *state.AddNoticeOptions) error {
@@ -139,12 +139,12 @@ func (s *accessruleSuite) TestCreateDeleteAccessRuleSimple(c *C) {
 		c.Assert(pathID, Equals, accessRule.ID)
 	}
 
-	deletedRule, err := ardb.DeleteAccessRule(user, accessRule.ID)
+	removedRule, err := ardb.RemoveAccessRule(user, accessRule.ID)
 	c.Assert(err, IsNil)
-	c.Assert(deletedRule, DeepEquals, accessRule)
+	c.Assert(removedRule, DeepEquals, accessRule)
 
 	c.Assert(ruleNoticeIDs, HasLen, 1, Commentf("ruleNoticeIDs: %v; ardb.ByID: %+v", ruleNoticeIDs, ardb.ByID))
-	c.Check(ruleNoticeIDs[0], Equals, deletedRule.ID)
+	c.Check(ruleNoticeIDs[0], Equals, removedRule.ID)
 	ruleNoticeIDs = ruleNoticeIDs[1:]
 
 	c.Assert(ardb.ByID, HasLen, 0)


### PR DESCRIPTION
The term "remove" is commonly used in snapd in place of "delete", so make the prompting API and internals use "remove" as well.
