### PR TITLE
o/i/apparmorprompting: add constraints fields to prompts and rules

### DIFF
--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -69,6 +69,29 @@ const (
 	PermissionChangeProfileOnExec PermissionType = "change-profile-on-exec"
 )
 
+var AllPermissions = []PermissionType{
+	PermissionExecute,
+	PermissionWrite,
+	PermissionRead,
+	PermissionAppend,
+	PermissionCreate,
+	PermissionDelete,
+	PermissionOpen,
+	PermissionRename,
+	PermissionSetAttr,
+	PermissionGetAttr,
+	PermissionSetCred,
+	PermissionGetCred,
+	PermissionChangeMode,
+	PermissionChangeOwner,
+	PermissionChangeGroup,
+	PermissionLock,
+	PermissionExecuteMap,
+	PermissionLink,
+	PermissionChangeProfile,
+	PermissionChangeProfileOnExec,
+}
+
 // If kernel request contains multiple interfaces, one must take priority.
 // Lower value is higher priority, and entries should be in priority order.
 var interfacePriorities = map[string]int{

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -239,12 +239,12 @@ func (p *Prompting) PostPrompt(userID uint32, promptID string, reply *PromptRepl
 	// interfaces, so we do not assert anything else particular about the
 	// reply.PathPattern.
 	// TODO: Should this be reconsidered?
-	matches, err := common.PathPatternMatches(reply.PathPattern, prompt.Path)
+	matches, err := prompt.Constraints.Matches(reply.PathPattern)
 	if err != nil {
-		return nil, common.ErrInvalidPathPattern
+		return nil, err
 	}
 	if !matches {
-		return nil, fmt.Errorf("path pattern in reply does not match originally requested path: '%s' does not match '%s'; skipping rule generation", reply.PathPattern, prompt.Path)
+		return nil, fmt.Errorf("path pattern in reply does not match originally requested path: '%s' does not match '%v'; skipping rule generation", reply.PathPattern, prompt.Constraints)
 	}
 
 	// Create new rule based on the reply.

--- a/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
+++ b/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
@@ -90,8 +90,8 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	c.Check(prompt1.Snap, Equals, snap)
 	c.Check(prompt1.App, Equals, app)
 	c.Check(prompt1.Interface, Equals, iface)
-	c.Check(prompt1.Path, Equals, path)
-	c.Check(prompt1.Permissions, DeepEquals, permissions)
+	c.Check(prompt1.Constraints.Path, Equals, path)
+	c.Check(prompt1.Constraints.Permissions, DeepEquals, permissions)
 
 	stored = pdb.Prompts(user)
 	c.Assert(stored, HasLen, 1)


### PR DESCRIPTION
Add a "constraints" field to prompts and rules, where the constraints vary by interface.

For prompts, the constraints are the details of the object of the request, including any permissions which are being requested.

For rules, the constraints are the details of which future requests/prompts the rule applies to.