### PR TITLE
daemon,o/i/apparmorprompting: remove "app" from prompts and rules

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -155,7 +155,6 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 	query := r.URL.Query()
 
 	snap := query.Get("snap")
-	app := query.Get("app")
 	iface := query.Get("interface")
 
 	ucred, err := ucrednetGet(r.RemoteAddr)
@@ -163,13 +162,10 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		return Forbidden("cannot get remote user: %v", err)
 	}
 
-	if app != "" && snap == "" {
-		return BadRequest(`"app" field provided, must also provide "snap" field`)
-	}
 	if iface != "" && snap == "" {
 		return BadRequest(`"interface" field provided, must also provide "snap" field`)
 	}
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, app, iface)
+	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, iface)
 	if err != nil {
 		return InternalError("%v", err)
 	}

--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap and app")
+	ErrInvalidSnapLabel           = errors.New("the given label cannot be converted to snap")
 	ErrInvalidOutcome             = errors.New(`invalid outcome; must be "allow" or "deny"`)
 	ErrInvalidLifespan            = errors.New("invalid lifespan")
 	ErrInvalidDurationForLifespan = fmt.Errorf(`invalid duration: duration must be empty unless lifespan is "%v"`, LifespanTimespan)
@@ -153,17 +153,15 @@ func NewIDAndTimestamp() (id string, timestamp string) {
 	return id, timestamp
 }
 
-// Extracts the snap and app names from the given label.
-// If the label is not of the form 'snap.<snap>.<app>', returns an error, and
-// returns the label as both the snap and the app.
-func LabelToSnapApp(label string) (snap string, app string, err error) {
+// Extracts the snap name from the given label. If the label is not of the form
+// 'snap.<snap>.<app>', returns an error, and returns the label as the snap.
+func LabelToSnap(label string) (string, error) {
 	components := strings.Split(label, ".")
 	if len(components) != 3 || components[0] != "snap" {
-		return label, label, ErrInvalidSnapLabel
+		return label, ErrInvalidSnapLabel
 	}
-	snap = components[1]
-	app = components[2]
-	return snap, app, nil
+	snap := components[1]
+	return snap, nil
 }
 
 var (

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -373,37 +373,32 @@ func (s *commonSuite) TestNewIDAndTimestamp(c *C) {
 	c.Assert(parsedTimePaired, Equals, parsedTimestamp)
 }
 
-func (s *commonSuite) TestLabelToSnapAppHappy(c *C) {
+func (s *commonSuite) TestLabelToSnap(c *C) {
 	cases := []struct {
 		label string
 		snap  string
-		app   string
 	}{
 		{
 			label: "snap.nextcloud.occ",
 			snap:  "nextcloud",
-			app:   "occ",
 		},
 		{
 			label: "snap.lxd.lxc",
 			snap:  "lxd",
-			app:   "lxc",
 		},
 		{
 			label: "snap.firefox.firefox",
 			snap:  "firefox",
-			app:   "firefox",
 		},
 	}
 	for _, testCase := range cases {
-		snap, app, err := common.LabelToSnapApp(testCase.label)
+		snap, err := common.LabelToSnap(testCase.label)
 		c.Check(err, IsNil)
 		c.Check(snap, Equals, testCase.snap)
-		c.Check(app, Equals, testCase.app)
 	}
 }
 
-func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
+func (s *commonSuite) TestLabelToSnapUnhappy(c *C) {
 	cases := []string{
 		"snap",
 		"snap.nextcloud",
@@ -412,10 +407,9 @@ func (s *commonSuite) TestLabelToSnapAppUnhappy(c *C) {
 		"SNAP.NEXTCLOUD.OCC",
 	}
 	for _, label := range cases {
-		snap, app, err := common.LabelToSnapApp(label)
+		snap, err := common.LabelToSnap(label)
 		c.Check(err, Equals, common.ErrInvalidSnapLabel)
 		c.Check(snap, Equals, label)
-		c.Check(app, Equals, label)
 	}
 }
 

--- a/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
+++ b/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
@@ -54,7 +54,6 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 
 	pdb := requestprompts.New(notifyPrompt)
 	snap := "nextcloud"
-	app := "occ"
 	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read", "write", "execute"}
@@ -67,7 +66,7 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	c.Assert(stored, HasLen, 0)
 
 	before := time.Now()
-	prompt1, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
 	after := time.Now()
 	c.Assert(merged, Equals, false)
 
@@ -75,7 +74,7 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	c.Check(promptNoticeIDs[0], Equals, prompt1.ID)
 	promptNoticeIDs = promptNoticeIDs[1:]
 
-	prompt2, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
 	c.Assert(merged, Equals, true)
 	c.Assert(prompt2, Equals, prompt1)
 
@@ -88,7 +87,6 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	c.Check(timestamp.Before(after), Equals, true)
 
 	c.Check(prompt1.Snap, Equals, snap)
-	c.Check(prompt1.App, Equals, app)
 	c.Check(prompt1.Interface, Equals, iface)
 	c.Check(prompt1.Constraints.Path, Equals, path)
 	c.Check(prompt1.Constraints.Permissions, DeepEquals, permissions)
@@ -104,7 +102,7 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	// Looking up prompt should not trigger notice
 	c.Assert(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	prompt3, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, true)
 	c.Check(prompt3, Equals, prompt1)
 
@@ -129,14 +127,13 @@ func (s *requestpromptsSuite) TestPromptWithIDErrors(c *C) {
 
 	pdb := requestprompts.New(notifyPrompt)
 	snap := "nextcloud"
-	app := "occ"
 	iface := "system-files"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read", "write", "execute"}
 
 	listenerReq := &listener.Request{}
 
-	prompt, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 1, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
@@ -179,7 +176,6 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 
 	pdb := requestprompts.New(notifyPrompt)
 	snap := "nextcloud"
-	app := "occ"
 	iface := "personal-files"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read", "write", "execute"}
@@ -187,14 +183,14 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 	listenerReq1 := &listener.Request{}
 	listenerReq2 := &listener.Request{}
 
-	prompt1, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 1, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 	c.Check(promptNoticeIDs[0], Equals, prompt1.ID)
 	promptNoticeIDs = promptNoticeIDs[1:]
 
-	prompt2, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, true)
 	c.Check(prompt2, Equals, prompt1)
 
@@ -220,14 +216,14 @@ func (s *requestpromptsSuite) TestReply(c *C) {
 	listenerReq1 = &listener.Request{}
 	listenerReq2 = &listener.Request{}
 
-	prompt1, merged = pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
+	prompt1, merged = pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 1, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 	c.Check(promptNoticeIDs[0], Equals, prompt1.ID)
 	promptNoticeIDs = promptNoticeIDs[1:]
 
-	prompt2, merged = pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
+	prompt2, merged = pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, true)
 	c.Check(prompt2, Equals, prompt1)
 
@@ -269,14 +265,13 @@ func (s *requestpromptsSuite) TestReplyErrors(c *C) {
 
 	pdb := requestprompts.New(notifyPrompt)
 	snap := "nextcloud"
-	app := "occ"
 	iface := "removable-media"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read", "write", "execute"}
 
 	listenerReq := &listener.Request{}
 
-	prompt, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 1, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
@@ -322,28 +317,27 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 	pdb := requestprompts.New(notifyPrompt)
 
 	snap := "nextcloud"
-	app := "occ"
 	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 
 	permissions := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq4)
+	prompt4, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 4, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
@@ -364,7 +358,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 		Permissions: permissions,
 	}
 
-	satisfied, err := pdb.HandleNewRule(user, snap, app, iface, constraints, outcome)
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, outcome)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 2)
 	c.Check(strutil.ListContains(satisfied, prompt2.ID), Equals, true)
@@ -401,7 +395,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleAllowPermissions(c *C) {
 		PathPattern: pathPattern,
 		Permissions: permissions,
 	}
-	satisfied, err = pdb.HandleNewRule(user, snap, app, iface, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, constraints, outcome)
 
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 1)
@@ -439,28 +433,27 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	pdb := requestprompts.New(notifyPrompt)
 
 	snap := "nextcloud"
-	app := "occ"
 	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 
 	permissions := []string{"read", "write", "execute"}
 	listenerReq1 := &listener.Request{}
-	prompt1, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq1)
+	prompt1, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq1)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"read", "write"}
 	listenerReq2 := &listener.Request{}
-	prompt2, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq2)
+	prompt2, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq2)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"read"}
 	listenerReq3 := &listener.Request{}
-	prompt3, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq3)
+	prompt3, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq3)
 	c.Check(merged, Equals, false)
 
 	permissions = []string{"open"}
 	listenerReq4 := &listener.Request{}
-	prompt4, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq4)
+	prompt4, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq4)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 4, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
@@ -482,7 +475,7 @@ func (s *requestpromptsSuite) TestHandleNewRuleDenyPermissions(c *C) {
 	}
 
 	// If one or more permissions denied each for prompts 1-3, so each is denied
-	satisfied, err := pdb.HandleNewRule(user, snap, app, iface, constraints, outcome)
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, outcome)
 	c.Assert(err, IsNil)
 	c.Check(satisfied, HasLen, 3)
 	c.Check(strutil.ListContains(satisfied, prompt1.ID), Equals, true)
@@ -545,12 +538,11 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	pdb := requestprompts.New(notifyPrompt)
 
 	snap := "nextcloud"
-	app := "occ"
 	iface := "home"
 	path := "/home/test/Documents/foo.txt"
 	permissions := []string{"read"}
 	listenerReq := &listener.Request{}
-	prompt, merged := pdb.AddOrMerge(user, snap, app, iface, path, permissions, listenerReq)
+	prompt, merged := pdb.AddOrMerge(user, snap, iface, path, permissions, listenerReq)
 	c.Check(merged, Equals, false)
 
 	c.Assert(promptNoticeIDs, HasLen, 1, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
@@ -566,7 +558,6 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 
 	otherUser := user + 1
 	otherSnap := "ldx"
-	otherApp := "lxc"
 	otherInterface := "system-files"
 	otherPattern := "/home/test/Pictures/**.png"
 	otherConstraints := &common.Constraints{
@@ -584,49 +575,43 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Assert(stored, HasLen, 1)
 	c.Assert(stored[0], Equals, prompt)
 
-	satisfied, err := pdb.HandleNewRule(otherUser, otherSnap, otherApp, otherInterface, otherConstraints, badOutcome)
+	satisfied, err := pdb.HandleNewRule(otherUser, otherSnap, otherInterface, otherConstraints, badOutcome)
 	c.Check(err, Equals, common.ErrInvalidOutcome)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(otherUser, otherSnap, otherApp, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(otherUser, otherSnap, otherInterface, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, otherSnap, otherApp, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, otherSnap, otherInterface, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, snap, otherApp, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, otherInterface, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, snap, app, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, otherConstraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, snap, app, iface, otherConstraints, outcome)
-	c.Check(err, IsNil)
-	c.Check(satisfied, HasLen, 0)
-
-	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
-
-	satisfied, err = pdb.HandleNewRule(user, snap, app, iface, badConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, badConstraints, outcome)
 	c.Check(err, ErrorMatches, "syntax error in pattern")
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, snap, app, iface, constraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, iface, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Assert(satisfied, HasLen, 1)
 

--- a/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
+++ b/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
@@ -575,25 +575,25 @@ func (s *requestpromptsSuite) TestHandleNewRuleNonMatches(c *C) {
 	c.Assert(stored, HasLen, 1)
 	c.Assert(stored[0], Equals, prompt)
 
-	satisfied, err := pdb.HandleNewRule(otherUser, otherSnap, otherInterface, otherConstraints, badOutcome)
+	satisfied, err := pdb.HandleNewRule(user, snap, iface, constraints, badOutcome)
 	c.Check(err, Equals, common.ErrInvalidOutcome)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(otherUser, otherSnap, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(otherUser, snap, iface, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, otherSnap, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, otherSnap, iface, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 
 	c.Check(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	satisfied, err = pdb.HandleNewRule(user, snap, otherInterface, otherConstraints, outcome)
+	satisfied, err = pdb.HandleNewRule(user, snap, otherInterface, constraints, outcome)
 	c.Check(err, IsNil)
 	c.Check(satisfied, HasLen, 0)
 


### PR DESCRIPTION
AppArmor permissions are granted by interfaces according to plugs/slots which may or may not differ between apps within a given snap. For the home interface, for example, there is never an instance where one app within a snap is granted a permission that another app in that same snap is not. Thus, it does not make sense for a rule to apply to only a single app within a snap.

Instead, the interface field should optionally include the name of the plug or slot which granted the permissions, which should be received from the kernel using message tagging. The result should be of the form:

`<interface name>[/<plug or slot>]`

As such, rules should no longer be associated with a particular app, and in order to match, neither should request prompts. Adjustments are made to the prompting API to remove the "app" parameter when querying rules.
