### PR TITLE
daemon,o/i/apparmorprompting{,common}: allow filtering rules by interface without snap filter

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -161,10 +161,6 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 	if err != nil {
 		return Forbidden("cannot get remote user: %v", err)
 	}
-
-	if iface != "" && snap == "" {
-		return BadRequest(`"interface" field provided, must also provide "snap" field`)
-	}
 	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(ucred.Uid, snap, iface)
 	if err != nil {
 		return InternalError("%v", err)

--- a/overlord/ifacestate/apparmorprompting/prompting.go
+++ b/overlord/ifacestate/apparmorprompting/prompting.go
@@ -310,13 +310,16 @@ func (p *Prompting) GetRules(userID uint32, snap string, iface string) ([]*reque
 	if !PromptingEnabled() {
 		return nil, fmt.Errorf("AppArmor Prompting is not enabled")
 	}
-	// Daemon already checked that if iface != "", then snap != ""
-	if iface != "" {
-		rules := p.rules.RulesForSnapInterface(userID, snap, iface)
+	if snap != "" {
+		if iface != "" {
+			rules := p.rules.RulesForSnapInterface(userID, snap, iface)
+			return rules, nil
+		}
+		rules := p.rules.RulesForSnap(userID, snap)
 		return rules, nil
 	}
-	if snap != "" {
-		rules := p.rules.RulesForSnap(userID, snap)
+	if iface != "" {
+		rules := p.rules.RulesForInterface(userID, iface)
 		return rules, nil
 	}
 	rules := p.rules.Rules(userID)

--- a/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
+++ b/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
@@ -624,12 +624,22 @@ func (rdb *RuleDB) rulesInternal(ruleFilter func(rule *Rule) bool) []*Rule {
 	return rules
 }
 
-// Returns all rules which apply to the given user and the given snap.
+// Returns all rules which apply to the given user and snap.
 func (rdb *RuleDB) RulesForSnap(user uint32, snap string) []*Rule {
 	rdb.mutex.Lock()
 	defer rdb.mutex.Unlock()
 	ruleFilter := func(rule *Rule) bool {
 		return rule.User == user && rule.Snap == snap
+	}
+	return rdb.rulesInternal(ruleFilter)
+}
+
+// Returns all rules which apply to the given user and interface.
+func (rdb *RuleDB) RulesForInterface(user uint32, iface string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Interface == iface
 	}
 	return rdb.rulesInternal(ruleFilter)
 }


### PR DESCRIPTION
Previously, rules could be filtered by snap or by snap+interface, but not by interface alone. This PR allows filtering rules by interface without providing a snap filter as well.