### PR TITLE
daemon: expand snap-prompting-control api access

### DIFF
--- a/daemon/api_general.go
+++ b/daemon/api_general.go
@@ -54,7 +54,7 @@ var (
 	sysInfoCmd = &Command{
 		Path:       "/v2/system-info",
 		GET:        sysInfo,
-		ReadAccess: openAccess{},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-prompting-control"}},
 	}
 
 	stateChangeCmd = &Command{

--- a/daemon/api_general_test.go
+++ b/daemon/api_general_test.go
@@ -51,6 +51,10 @@ type generalSuite struct {
 	apiBaseSuite
 }
 
+func (s *generalSuite) expectSystemInfoReadAccess() {
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-prompting-control"}})
+}
+
 func (s *generalSuite) expectChangesReadAccess() {
 	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
 }
@@ -77,6 +81,7 @@ func (s *generalSuite) TestRoot(c *check.C) {
 }
 
 func (s *generalSuite) TestSysInfo(c *check.C) {
+	s.expectSystemInfoReadAccess()
 	req, err := http.NewRequest("GET", "/v2/system-info", nil)
 	c.Assert(err, check.IsNil)
 
@@ -197,6 +202,7 @@ func (s *generalSuite) TestSysInfo(c *check.C) {
 }
 
 func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
+	s.expectSystemInfoReadAccess()
 	req, err := http.NewRequest("GET", "/v2/system-info", nil)
 	c.Assert(err, check.IsNil)
 
@@ -278,6 +284,7 @@ func (s *generalSuite) TestSysInfoLegacyRefresh(c *check.C) {
 }
 
 func (s *generalSuite) testSysInfoSystemMode(c *check.C, mode string) {
+	s.expectSystemInfoReadAccess()
 	req, err := http.NewRequest("GET", "/v2/system-info", nil)
 	c.Assert(err, check.IsNil)
 
@@ -369,6 +376,7 @@ func (s *generalSuite) TestSysInfoSystemModeInstall(c *check.C) {
 	s.testSysInfoSystemMode(c, "install")
 }
 func (s *generalSuite) TestSysInfoIsManaged(c *check.C) {
+	s.expectSystemInfoReadAccess()
 	d := s.daemon(c)
 
 	st := d.Overlord().State()
@@ -390,6 +398,7 @@ func (s *generalSuite) TestSysInfoIsManaged(c *check.C) {
 }
 
 func (s *generalSuite) TestSysInfoWorksDegraded(c *check.C) {
+	s.expectSystemInfoReadAccess()
 	d := s.daemon(c)
 
 	d.SetDegradedMode(fmt.Errorf("some error"))

--- a/daemon/api_notices.go
+++ b/daemon/api_notices.go
@@ -29,21 +29,23 @@ import (
 )
 
 var noticeReadInterfaces = map[state.NoticeType][]string{
-	state.ChangeUpdateNotice:   {"snap-refresh-observe"},
-	state.RefreshInhibitNotice: {"snap-refresh-observe"},
+	state.ChangeUpdateNotice:       {"snap-refresh-observe"},
+	state.RefreshInhibitNotice:     {"snap-refresh-observe"},
+	state.RequestsPromptNotice:     {"snap-prompting-control"},
+	state.RequestsRuleUpdateNotice: {"snap-prompting-control"},
 }
 
 var (
 	noticesCmd = &Command{
 		Path:       "/v2/notices",
 		GET:        getNotices,
-		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "snap-prompting-control"}},
 	}
 
 	noticeCmd = &Command{
 		Path:       "/v2/notices/{id}",
 		GET:        getNotice,
-		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}},
+		ReadAccess: interfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "snap-prompting-control"}},
 	}
 )
 

--- a/daemon/api_notices_test.go
+++ b/daemon/api_notices_test.go
@@ -40,7 +40,7 @@ type noticesSuite struct {
 func (s *noticesSuite) SetUpTest(c *C) {
 	s.apiBaseSuite.SetUpTest(c)
 
-	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe"}})
+	s.expectReadAccess(daemon.InterfaceOpenAccess{Interfaces: []string{"snap-refresh-observe", "snap-prompting-control"}})
 }
 
 func (s *noticesSuite) TestNoticesFilterUserID(c *C) {
@@ -229,9 +229,12 @@ func (s *noticesSuite) TestNoticesShowsTypesAllowedForSnap(c *C) {
 
 	st := s.d.Overlord().State()
 	st.Lock()
+	addNotice(c, st, nil, state.RequestsPromptNotice, "abc", nil)
+	addNotice(c, st, nil, state.RequestsRuleUpdateNotice, "xyz", nil)
 	addNotice(c, st, nil, state.ChangeUpdateNotice, "123", nil)
 	addNotice(c, st, nil, state.RefreshInhibitNotice, "-", nil)
 	addNotice(c, st, nil, state.WarningNotice, "danger", nil)
+	addNotice(c, st, nil, state.RequestsPromptNotice, "def", nil)
 	st.Unlock()
 
 	// Check that a snap request without specifying types filter only shows
@@ -265,6 +268,28 @@ func (s *noticesSuite) TestNoticesShowsTypesAllowedForSnap(c *C) {
 	}
 	c.Check(seenNoticeType["change-update"], Equals, 1)
 	c.Check(seenNoticeType["refresh-inhibit"], Equals, 1)
+
+	// Check that multiple interfaces allow accessing notice types granted by
+	// any of the connected interfaces
+	req, err = http.NewRequest("GET", "/v2/notices", nil)
+	c.Assert(err, IsNil)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-refresh-observe&snap-prompting-control;", dirs.SnapSocket)
+	rsp = s.syncReq(c, req, nil)
+	c.Check(rsp.Status, Equals, 200)
+	notices, ok = rsp.Result.([]*state.Notice)
+	c.Assert(ok, Equals, true)
+	c.Assert(notices, HasLen, 5)
+
+	seenNoticeType = make(map[string]int)
+	for _, notice := range notices {
+		n := noticeToMap(c, notice)
+		noticeType := n["type"].(string)
+		seenNoticeType[noticeType]++
+	}
+	c.Check(seenNoticeType["change-update"], Equals, 1)
+	c.Check(seenNoticeType["refresh-inhibit"], Equals, 1)
+	c.Check(seenNoticeType["interfaces-requests-prompt"], Equals, 2)
+	c.Check(seenNoticeType["interfaces-requests-rule-update"], Equals, 1)
 }
 
 func (s *noticesSuite) TestNoticesFilterTypesForSnap(c *C) {
@@ -327,17 +352,17 @@ func (s *noticesSuite) TestNoticesFilterTypesForSnapForbidden(c *C) {
 	rsp = s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 403)
 
-	// snap-themes-control doesn't give access to change-update notices.
+	// snap-prompting-control doesn't give access to change-update notices.
 	req, err = http.NewRequest("GET", "/v2/notices?types=change-update", nil)
 	c.Assert(err, IsNil)
-	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-themes-control;", dirs.SnapSocket)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-prompting-control;", dirs.SnapSocket)
 	rsp = s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 403)
 
-	// snap-themes-control doesn't give access to refresh-inhibit notices.
+	// snap-prompting-control doesn't give access to refresh-inhibit notices.
 	req, err = http.NewRequest("GET", "/v2/notices?types=refresh-inhibit", nil)
 	c.Assert(err, IsNil)
-	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-themes-control;", dirs.SnapSocket)
+	req.RemoteAddr = fmt.Sprintf("pid=100;uid=1000;socket=%s;iface=snap-prompting-control;", dirs.SnapSocket)
 	rsp = s.errorReq(c, req, nil)
 	c.Check(rsp.Status, Equals, 403)
 


### PR DESCRIPTION
Expand the `snap-prompting-control` interface to grant access to `/v2/system-info` endpoint and the `"interfaces-requests-prompt"` and `"interfaces-requests-rule-update"` notice types via the `/v2/notices` endpoint.