### PR TITLE
o/i/apparmorprompting: make timestamp time.Time and expiration *time.Time

### DIFF
--- a/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts.go
+++ b/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
 	"github.com/snapcore/snapd/overlord/state"
@@ -16,7 +17,7 @@ var ErrUserNotFound = errors.New("no prompts found for the given user")
 
 type Prompt struct {
 	ID           string              `json:"id"`
-	Timestamp    string              `json:"timestamp"`
+	Timestamp    time.Time           `json:"timestamp"`
 	Snap         string              `json:"snap"`
 	Interface    string              `json:"interface"`
 	Constraints  *promptConstraints  `json:"constraints"`

--- a/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
+++ b/overlord/ifacestate/apparmorprompting/requestprompts/requestprompts_test.go
@@ -81,10 +81,8 @@ func (s *requestpromptsSuite) TestAddOrMergePrompt(c *C) {
 	// Merged prompts should not trigger notice
 	c.Assert(promptNoticeIDs, HasLen, 0, Commentf("promptNoticeIDs: %v; pdb.PerUser[%d]: %+v", promptNoticeIDs, user, pdb.PerUser[user]))
 
-	timestamp, err := common.TimestampToTime(prompt1.Timestamp)
-	c.Assert(err, IsNil)
-	c.Check(timestamp.After(before), Equals, true)
-	c.Check(timestamp.Before(after), Equals, true)
+	c.Check(prompt1.Timestamp.After(before), Equals, true)
+	c.Check(prompt1.Timestamp.Before(after), Equals, true)
 
 	c.Check(prompt1.Snap, Equals, snap)
 	c.Check(prompt1.Interface, Equals, iface)


### PR DESCRIPTION
Since `time.Time` values are marshalled as RFC3339Nano by default, there is no reason to explicitly save timestamps and expirations as strings and convert them to `time.Time` on the fly as necessary. Let the marshaller do this automatically.

As expirations should only be populated when lifespan is "timespan", expirations can be stored as `*time.Time`, which should be encoded as `nil` when empty and an expiration timestamp in RFC3339Nano format when non-empty.
