### PR TITLE
o/i/apparmorprompting/common: map get-attr and set-attr to read and write

### DIFF
--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -164,8 +164,8 @@ var (
 	// and if it does not, it should be interpreted as AA_MAY_READ.
 	interfaceFilePermissionsMaps = map[string]map[string]notify.FilePermission{
 		"home": {
-			"read":    notify.AA_MAY_READ,
-			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			"read":    notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
+			"write":   notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 			"execute": notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
 		},
 		"camera": {

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -740,7 +740,7 @@ func (s *commonSuite) TestAbstractPermissionsFromAppArmorFilePermissionsUnhappy(
 		},
 		{
 			"home",
-			notify.AA_MAY_GETATTR | notify.AA_MAY_READ,
+			notify.AA_MAY_GETCRED | notify.AA_MAY_READ,
 			"received unexpected permission for interface.*",
 		},
 		{
@@ -848,12 +848,12 @@ func (s *commonSuite) TestAbstractPermissionsToAppArmorFilePermissionsHappy(c *C
 		{
 			"home",
 			[]string{"read"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR,
 		},
 		{
 			"home",
 			[]string{"write"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			notify.AA_MAY_OPEN | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 		},
 		{
 			"home",
@@ -863,12 +863,12 @@ func (s *commonSuite) TestAbstractPermissionsToAppArmorFilePermissionsHappy(c *C
 		{
 			"home",
 			[]string{"read", "execute"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP,
 		},
 		{
 			"home",
 			[]string{"execute", "write", "read"},
-			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
+			notify.AA_MAY_OPEN | notify.AA_MAY_READ | notify.AA_MAY_GETATTR | notify.AA_MAY_EXEC | notify.AA_EXEC_MMAP | notify.AA_MAY_WRITE | notify.AA_MAY_APPEND | notify.AA_MAY_CREATE | notify.AA_MAY_DELETE | notify.AA_MAY_RENAME | notify.AA_MAY_SETATTR | notify.AA_MAY_CHMOD | notify.AA_MAY_LOCK | notify.AA_MAY_LINK,
 		},
 		{
 			"camera",


### PR DESCRIPTION
This is a backport of https://github.com/snapcore/snapd/pull/14142 to the old `common` package in the prompting branch.

Once the following PRs are merged, the `common` package should be removed entirely and replaced by the packages in `interfaces/prompting`:
- https://github.com/snapcore/snapd/pull/13868
- https://github.com/snapcore/snapd/pull/14142

@sminez I'll merge this quickly, and that will trigger a rebuild of the latest/edge/prompting branch with the fix included.