### PR TITLE
o/i/apparmorprompting/common: do not error on unexpected apparmor perm

### DIFF
--- a/overlord/ifacestate/apparmorprompting/common/common.go
+++ b/overlord/ifacestate/apparmorprompting/common/common.go
@@ -11,6 +11,7 @@ import (
 
 	doublestar "github.com/bmatcuk/doublestar/v4"
 
+	"github.com/snapcore/snapd/logger"
 	"github.com/snapcore/snapd/sandbox/apparmor/notify"
 	"github.com/snapcore/snapd/strutil"
 )
@@ -247,7 +248,15 @@ func abstractPermissionsFromAppArmorFilePermissions(iface string, permissions in
 		}
 	}
 	if filePerms != notify.FilePermission(0) {
-		return nil, fmt.Errorf("received unexpected permission for interface %s in AppArmor permission mask: %v", iface, filePerms)
+		logger.Noticef("WARNING: cannot map AppArmor permission to abstract permission for the %s interface: %q", iface, filePerms)
+		// Replying to request sends back original (allow | deny) permissions as
+		// allowed, so permissions which are unknown/excluded here will still be
+		// included in the final reply notification (as we desire).
+		//
+		// XXX: If we instead send back the explicit permissions which the user
+		// allowed (or denied), need to be careful to re-include permissions
+		// which were originally requested but were not mapped to abstract
+		// permissions.
 	}
 	if len(abstractPerms) == 0 {
 		origMask := permissions.(notify.FilePermission)

--- a/overlord/ifacestate/apparmorprompting/common/common_test.go
+++ b/overlord/ifacestate/apparmorprompting/common/common_test.go
@@ -700,6 +700,18 @@ func (s *commonSuite) TestAbstractPermissionsFromAppArmorFilePermissionsHappy(c 
 			[]string{"read", "write", "execute"},
 		},
 		{
+			// Check that unmapped permissions are discarded without error
+			"home",
+			notify.AA_MAY_READ | notify.AA_MAY_GETCRED,
+			[]string{"read"},
+		},
+		{
+			// Check that unknown permissions are discarded without error
+			"home",
+			notify.AA_MAY_READ | notify.FilePermission(1<<17),
+			[]string{"read"},
+		},
+		{
 			"camera",
 			notify.AA_MAY_WRITE | notify.AA_MAY_READ | notify.AA_MAY_APPEND,
 			[]string{"access"},
@@ -735,27 +747,17 @@ func (s *commonSuite) TestAbstractPermissionsFromAppArmorFilePermissionsUnhappy(
 		},
 		{
 			"home",
-			notify.FilePermission(1 << 17),
-			"received unexpected permission for interface.*",
-		},
-		{
-			"home",
-			notify.AA_MAY_GETCRED | notify.AA_MAY_READ,
-			"received unexpected permission for interface.*",
-		},
-		{
-			"camera",
-			notify.AA_MAY_EXEC,
-			"received unexpected permission for interface.*",
-		},
-		{
-			"camera",
-			notify.AA_MAY_EXEC | notify.AA_MAY_READ,
-			"received unexpected permission for interface.*",
-		},
-		{
-			"home",
 			notify.FilePermission(0),
+			"no abstract permissions.*",
+		},
+		{
+			"home",
+			notify.FilePermission(1 << 17),
+			"no abstract permissions.*",
+		},
+		{
+			"home",
+			notify.AA_MAY_GETCRED,
 			"no abstract permissions.*",
 		},
 	}


### PR DESCRIPTION
Rather than returning an error when there is no abstract permission mapping to a received AppArmor file permission, instead log a message with a warning and omit AppArmor permission from the abstract permissions list.

Because the final reply notification is constructed from the originally-requested permissions, rather than the AppArmor permissions corresponding to the abstract permissions the user supplied, the ignored unexpected permission will still be included in the reply.

If, in the future, this changes, further changes will be required to ensure that requested permissions which are not mapped to an abstract permission are still included in the reply notification message.
