### PR TITLE
many: return more specific error codes from prompting API endpoints

### DIFF
--- a/daemon/api_prompting.go
+++ b/daemon/api_prompting.go
@@ -21,12 +21,16 @@ package daemon
 
 import (
 	"encoding/json"
+	"errors"
 	"math"
 	"net/http"
 	"strconv"
 
 	"github.com/snapcore/snapd/overlord/auth"
 	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/common"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestprompts"
+	"github.com/snapcore/snapd/overlord/ifacestate/apparmorprompting/requestrules"
 	"github.com/snapcore/snapd/strutil"
 )
 
@@ -73,35 +77,6 @@ func userNotAllowedPromptingClientResponse(user *auth.UserState) Response {
 	return Forbidden("user not allowed")
 }
 
-type postRulesRequestBody struct {
-	Action         string                                 `json:"action"`
-	AddRule        *apparmorprompting.AddRuleContents     `json:"rule,omitempty"`
-	RemoveSelector *apparmorprompting.RemoveRulesSelector `json:"selector,omitempty"`
-}
-
-type postRuleRequestBody struct {
-	Action    string                               `json:"action"`
-	PatchRule *apparmorprompting.PatchRuleContents `json:"rule,omitempty"`
-}
-
-func getPrompts(c *Command, r *http.Request, user *auth.UserState) Response {
-	if !userAllowedPromptingClient(user) {
-		return userNotAllowedPromptingClientResponse(user)
-	}
-
-	userID, errorResp := getUserID(r)
-	if errorResp != nil {
-		return errorResp
-	}
-
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetPrompts(userID)
-	if err != nil {
-		return InternalError("%v", err)
-	}
-
-	return SyncResponse(result)
-}
-
 // getUserID returns the UID specified by the user-id parameter of the query,
 // otherwise the UID of the connection.
 //
@@ -137,6 +112,70 @@ func getUserID(r *http.Request) (uint32, Response) {
 	return uint32(userIDInt), nil
 }
 
+type postPromptBody struct {
+	Outcome     common.OutcomeType  `json:"action"`
+	Lifespan    common.LifespanType `json:"lifespan"`
+	Duration    string              `json:"duration,omitempty"`
+	Constraints *common.Constraints `json:"constraints"`
+}
+
+type addRuleContents struct {
+	Snap        string              `json:"snap"`
+	Interface   string              `json:"interface"`
+	Constraints *common.Constraints `json:"constraints"`
+	Outcome     common.OutcomeType  `json:"outcome"`
+	Lifespan    common.LifespanType `json:"lifespan"`
+	Duration    string              `json:"duration,omitempty"`
+}
+
+type removeRulesSelector struct {
+	Snap      string `json:"snap"`
+	Interface string `json:"interface,omitempty"`
+}
+
+type patchRuleContents struct {
+	Constraints *common.Constraints `json:"constraints,omitempty"`
+	Outcome     common.OutcomeType  `json:"outcome,omitempty"`
+	Lifespan    common.LifespanType `json:"lifespan,omitempty"`
+	Duration    string              `json:"duration,omitempty"`
+}
+
+type postRulesRequestBody struct {
+	Action         string               `json:"action"`
+	AddRule        *addRuleContents     `json:"rule,omitempty"`
+	RemoveSelector *removeRulesSelector `json:"selector,omitempty"`
+}
+
+type postRuleRequestBody struct {
+	Action    string             `json:"action"`
+	PatchRule *patchRuleContents `json:"rule,omitempty"`
+}
+
+func getPrompts(c *Command, r *http.Request, user *auth.UserState) Response {
+	if !userAllowedPromptingClient(user) {
+		return userNotAllowedPromptingClientResponse(user)
+	}
+
+	userID, errorResp := getUserID(r)
+	if errorResp != nil {
+		return errorResp
+	}
+
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
+	}
+
+	prompts, err := c.d.overlord.InterfaceManager().Prompting().GetPrompts(userID)
+	if err != nil {
+		return InternalError("%v", err)
+	}
+	if len(prompts) == 0 {
+		prompts = []*requestprompts.Prompt{}
+	}
+
+	return SyncResponse(prompts)
+}
+
 func getPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 	vars := muxVars(r)
 	id := vars["id"]
@@ -150,12 +189,18 @@ func getPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return errorResp
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetPrompt(userID, id)
-	if err != nil {
-		return InternalError("%v", err)
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
 	}
 
-	return SyncResponse(result)
+	prompt, err := c.d.overlord.InterfaceManager().Prompting().GetPromptWithID(userID, id)
+	if errors.Is(err, apparmorprompting.ErrPromptingNotEnabled) {
+		return InternalError("%v", err)
+	} else if err != nil {
+		return NotFound("%v", err)
+	}
+
+	return SyncResponse(prompt)
 }
 
 func postPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -171,18 +216,28 @@ func postPrompt(c *Command, r *http.Request, user *auth.UserState) Response {
 		return errorResp
 	}
 
-	var reply apparmorprompting.PromptReply
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
+	}
+
+	var reply postPromptBody
 	decoder := json.NewDecoder(r.Body)
 	if err := decoder.Decode(&reply); err != nil {
 		return BadRequest("cannot decode request body into prompt reply: %v", err)
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().PostPrompt(userID, id, &reply)
-	if err != nil {
-		return InternalError("%v", err)
+	satisfiedPromptIDs, err := c.d.overlord.InterfaceManager().Prompting().HandleReply(userID, id, reply.Constraints, reply.Outcome, reply.Lifespan, reply.Duration)
+	// TODO: once rebased on master, add to the following:
+	//if errors.Is(err, requestprompts.ErrClosed) {
+	//	return InternalError("%v", err)
+	//}
+	if errors.Is(err, requestprompts.ErrUserNotFound) || errors.Is(err, requestprompts.ErrPromptIDNotFound) {
+		return NotFound("%v", err)
+	} else if err != nil {
+		return BadRequest("%v", err)
 	}
 
-	return SyncResponse(result)
+	return SyncResponse(satisfiedPromptIDs)
 }
 
 func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -195,16 +250,20 @@ func getRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		return errorResp
 	}
 
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
+	}
+
 	query := r.URL.Query()
 	snap := query.Get("snap")
 	iface := query.Get("interface")
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRules(userID, snap, iface)
+	rules, err := c.d.overlord.InterfaceManager().Prompting().GetRules(userID, snap, iface)
 	if err != nil {
 		return InternalError("%v", err)
 	}
 
-	return SyncResponse(result)
+	return SyncResponse(rules)
 }
 
 func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -215,6 +274,10 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 	userID, errorResp := getUserID(r)
 	if errorResp != nil {
 		return errorResp
+	}
+
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
 	}
 
 	var postBody postRulesRequestBody
@@ -228,11 +291,11 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.AddRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "add"`)
 		}
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesAdd(userID, postBody.AddRule)
+		newRule, err := c.d.overlord.InterfaceManager().Prompting().AddRule(userID, postBody.AddRule.Snap, postBody.AddRule.Interface, postBody.AddRule.Constraints, postBody.AddRule.Outcome, postBody.AddRule.Lifespan, postBody.AddRule.Duration)
 		if err != nil {
-			return InternalError("%v", err)
+			return BadRequest("%v", err)
 		}
-		return SyncResponse(result)
+		return SyncResponse(newRule)
 	case "remove":
 		if postBody.RemoveSelector == nil {
 			return BadRequest(`must include "selector" field in request body when action is "remove"`)
@@ -240,11 +303,8 @@ func postRules(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.RemoveSelector.Snap == "" {
 			return BadRequest(`must include "snap" field in "selector"`)
 		}
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulesRemove(userID, postBody.RemoveSelector)
-		if err != nil {
-			return InternalError("%v", err)
-		}
-		return SyncResponse(result)
+		removedRules := c.d.overlord.InterfaceManager().Prompting().RemoveRules(userID, postBody.RemoveSelector.Snap, postBody.RemoveSelector.Interface)
+		return SyncResponse(removedRules)
 	default:
 		return BadRequest(`"action" field must be "create" or "remove"`)
 	}
@@ -263,12 +323,16 @@ func getRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		return errorResp
 	}
 
-	result, err := c.d.overlord.InterfaceManager().Prompting().GetRule(userID, id)
-	if err != nil {
-		return InternalError("%v", err)
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
 	}
 
-	return SyncResponse(result)
+	rule, err := c.d.overlord.InterfaceManager().Prompting().GetRule(userID, id)
+	if err != nil {
+		return NotFound("%v", err)
+	}
+
+	return SyncResponse(rule)
 }
 
 func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
@@ -277,6 +341,10 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 
 	if !userAllowedPromptingClient(user) {
 		return userNotAllowedPromptingClientResponse(user)
+	}
+
+	if !apparmorprompting.PromptingEnabled() {
+		return InternalError("Apparmor Prompting is not enabled")
 	}
 
 	var postBody postRuleRequestBody
@@ -295,17 +363,23 @@ func postRule(c *Command, r *http.Request, user *auth.UserState) Response {
 		if postBody.PatchRule == nil {
 			return BadRequest(`must include "rule" field in request body when action is "patch"`)
 		}
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRulePatch(userID, id, postBody.PatchRule)
-		if err != nil {
+		patchedRule, err := c.d.overlord.InterfaceManager().Prompting().PatchRule(userID, id, postBody.PatchRule.Constraints, postBody.PatchRule.Outcome, postBody.PatchRule.Lifespan, postBody.PatchRule.Duration)
+		if errors.Is(err, requestrules.ErrRuleIDNotFound) || errors.Is(err, requestrules.ErrUserNotAllowed) {
+			return NotFound("%v", err)
+		} else if errors.Is(err, requestrules.ErrInternalInconsistency) {
 			return InternalError("%v", err)
+		} else if err != nil {
+			return BadRequest("%v", err)
 		}
-		return SyncResponse(result)
+		return SyncResponse(patchedRule)
 	case "remove":
-		result, err := c.d.overlord.InterfaceManager().Prompting().PostRuleRemove(userID, id)
-		if err != nil {
+		removedRule, err := c.d.overlord.InterfaceManager().Prompting().RemoveRule(userID, id)
+		if errors.Is(err, requestrules.ErrRuleIDNotFound) || errors.Is(err, requestrules.ErrUserNotAllowed) {
+			return NotFound("%v", err)
+		} else if err != nil {
 			return InternalError("%v", err)
 		}
-		return SyncResponse(result)
+		return SyncResponse(removedRule)
 	default:
 		return BadRequest(`action must be "add" or "remove"`)
 	}

--- a/overlord/ifacestate/apparmorprompting/requestrules/export_test.go
+++ b/overlord/ifacestate/apparmorprompting/requestrules/export_test.go
@@ -1,0 +1,22 @@
+// -*- Mode: Go; indent-tabs-mode: t -*-
+
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+package requestrules
+
+var JoinInternalErrors = joinInternalErrors

--- a/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
+++ b/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
@@ -15,10 +15,13 @@ import (
 	"github.com/snapcore/snapd/overlord/state"
 )
 
-var ErrRuleIDNotFound = errors.New("rule ID is not found")
-var ErrPathPatternConflict = errors.New("a rule with the same path pattern already exists in the tree")
-var ErrNoMatchingRule = errors.New("no rules match the given path")
-var ErrUserNotAllowed = errors.New("the given user is not allowed to request the rule with the given ID")
+var (
+	ErrInternalInconsistency = errors.New("internal error: prompting rules database left inconsistent")
+	ErrRuleIDNotFound        = errors.New("rule ID is not found")
+	ErrPathPatternConflict   = errors.New("a rule with the same path pattern already exists in the tree")
+	ErrNoMatchingRule        = errors.New("no rules match the given path")
+	ErrUserNotAllowed        = errors.New("the given user is not allowed to request the rule with the given ID")
+)
 
 type Rule struct {
 	ID               string              `json:"id"`
@@ -158,31 +161,25 @@ func (rdb *RuleDB) addRulePermissionToTree(rule *Rule, permission string) (error
 // permission. If an expanded pattern is not found or maps to a different rule
 // ID than that of the given rule, continue to remove all other expanded paths
 // from the permission map (unless they map to a different rule ID), and return
-// an error.
-func (rdb *RuleDB) removeRulePermissionFromTree(rule *Rule, permission string) (err error) {
+// a slice of all errors which occurred.
+func (rdb *RuleDB) removeRulePermissionFromTree(rule *Rule, permission string) []error {
 	permPaths := rdb.permissionDBForUserSnapInterfacePermission(rule.User, rule.Snap, rule.Interface, permission)
+	var errs []error
 	for _, pathPattern := range rule.expandedPatterns {
 		id, exists := permPaths.PathRules[pathPattern]
 		if !exists {
 			// Database was left inconsistent, should not occur
-			err = appendError(err, fmt.Errorf(`expanded path pattern not found in the rule tree: %q`, pathPattern))
+			errs = append(errs, fmt.Errorf(`expanded path pattern not found in the rule tree: %q`, pathPattern))
 			continue
 		}
 		if id != rule.ID {
 			// Database was left inconsistent, should not occur
-			err = appendError(err, fmt.Errorf(`expanded path pattern maps to different rule ID: %q: %s`, pathPattern, id))
+			errs = append(errs, fmt.Errorf(`expanded path pattern maps to different rule ID: %q: %s`, pathPattern, id))
 			continue
 		}
 		delete(permPaths.PathRules, pathPattern)
 	}
-	return err
-}
-
-func appendError(prev, newest error) error {
-	if prev == nil {
-		return newest
-	}
-	return fmt.Errorf(`%v; %v`, prev, newest)
+	return errs
 }
 
 func (rdb *RuleDB) addRuleToTree(rule *Rule) (error, string, string) {
@@ -204,13 +201,44 @@ func (rdb *RuleDB) addRuleToTree(rule *Rule) (error, string, string) {
 
 func (rdb *RuleDB) removeRuleFromTree(rule *Rule) error {
 	// Fully removes the rule from the tree, even if an error occurs
-	var err error
+	var errs []error
 	for _, permission := range rule.Constraints.Permissions {
-		if e := rdb.removeRulePermissionFromTree(rule, permission); e != nil {
+		if es := rdb.removeRulePermissionFromTree(rule, permission); len(es) > 0 {
 			// Database was left inconsistent, should not occur.
-			// Store the error, but keep removing.
-			err = appendError(err, e)
+			// Store the errors, but keep removing.
+			errs = append(errs, es...)
 		}
+	}
+	return joinInternalErrors(errs)
+}
+
+func joinInternalErrors(errs []error) error {
+	joinedErr := errorsJoin(errs...)
+	if joinedErr == nil {
+		return nil
+	}
+	// TODO: wrap joinedErr as well once we're on golang v1.20+
+	return fmt.Errorf("%w\n%v", ErrInternalInconsistency, joinedErr)
+}
+
+// errorsJoin returns an error that wraps the given errors.
+// Any nil error values are discarded.
+// errorsJoin returns nil if every value in errs is nil.
+//
+// TODO: replace with errors.Join() once we're on golang v1.20+
+func errorsJoin(errs ...error) error {
+	var nonNilErrs []error
+	for _, e := range errs {
+		if e != nil {
+			nonNilErrs = append(nonNilErrs, e)
+		}
+	}
+	if len(nonNilErrs) == 0 {
+		return nil
+	}
+	err := nonNilErrs[0]
+	for _, e := range nonNilErrs[1:] {
+		err = fmt.Errorf("%w\n%v", err, e)
 	}
 	return err
 }
@@ -485,7 +513,7 @@ func (rdb *RuleDB) AddRule(user uint32, snap string, iface string, constraints *
 	return newRule, nil
 }
 
-// Removes the rule with the given ID from the rules database. If the rule
+// RemoveRule the rule with the given ID from the rules database. If the rule
 // does not apply to the given user, returns ErrUserNotAllowed. If successful,
 // saves the database to disk.
 func (rdb *RuleDB) RemoveRule(user uint32, id string) (*Rule, error) {
@@ -501,6 +529,42 @@ func (rdb *RuleDB) RemoveRule(user uint32, id string) (*Rule, error) {
 	rdb.save()
 	rdb.notifyRule(user, id, nil)
 	return rule, err
+}
+
+// RemoveRulesForSnap removes all rules pertaining to the given snap for the
+// user with the given user ID.
+func (rdb *RuleDB) RemoveRulesForSnap(user uint32, snap string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap
+	}
+	rules := rdb.rulesInternal(ruleFilter)
+	rdb.removeRulesInternal(user, rules)
+	return rules
+}
+
+func (rdb *RuleDB) removeRulesInternal(user uint32, rules []*Rule) {
+	for _, rule := range rules {
+		rdb.removeRuleFromTree(rule)
+		// If error occurs, rule was still fully removed from tree
+		delete(rdb.ByID, rule.ID)
+		rdb.notifyRule(user, rule.ID, nil)
+	}
+	rdb.save()
+}
+
+// RemoveRulesForSnapInterface removes all rules pertaining to the given snap
+// and interface for the user with the given user ID.
+func (rdb *RuleDB) RemoveRulesForSnapInterface(user uint32, snap string, iface string) []*Rule {
+	rdb.mutex.Lock()
+	defer rdb.mutex.Unlock()
+	ruleFilter := func(rule *Rule) bool {
+		return rule.User == user && rule.Snap == snap && rule.Interface == iface
+	}
+	rules := rdb.rulesInternal(ruleFilter)
+	rdb.removeRulesInternal(user, rules)
+	return rules
 }
 
 // Patches the rule with the given ID. The rule is modified by constructing a

--- a/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
+++ b/overlord/ifacestate/apparmorprompting/requestrules/requestrules.go
@@ -424,7 +424,7 @@ func (rdb *RuleDB) IsPathAllowed(user uint32, snap string, iface string, path st
 		matchingRule, exists := rdb.ByID[id]
 		if !exists {
 			// Database was left inconsistent, should not occur
-			delete(pathMap, id)
+			delete(pathMap, pathPattern)
 			// Issue a notice for the offending rule, just in case
 			rdb.notifyRule(user, id, nil)
 			continue


### PR DESCRIPTION
Rather than returning an `InternalError` whenever an error is encountered while handling a request, instead return more specific HTTP error codes when appropriate, such as `NotFound` (404) or `BadRequest` (400).

At the moment, large parts of the prompting branch (including the `common` and `requestprompts` packages) have undergone various improvements in the process of been merged into snapd master. Unfortunately, until the `requestrules` package is merged into snapd master, it is difficult to rebase the prompting branch on snapd master. As a result, some tweaks and TODOs have been added which are not especially relevant to the prompting API error code changes, but prepare for that eventual rebase.

A full rewrite of `overlord/ifacestate/apparmorprompting` is in order as well, and is planned once `requestrules` is finalized for snapd master.

This is tracked internally by: https://warthogs.atlassian.net/browse/SNAPDENG-22307